### PR TITLE
fix: enforce NEVM chain check when connecting EVM wallet

### DIFF
--- a/components/Bridge/NEVMStepWrapepr.tsx
+++ b/components/Bridge/NEVMStepWrapepr.tsx
@@ -1,6 +1,5 @@
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
-import { useConstants } from "@contexts/useConstants";
 import { Button } from "@mui/material";
 import { isValidEthereumAddress } from "@sidhujag/sysweb3-utils";
 import { useTransfer } from "./context/TransferContext";
@@ -14,9 +13,7 @@ const NEVMStepWrapper: React.FC<Props> = ({ children }) => {
   const { version, isBitcoinBased, switchTo, isEVMInjected } =
     usePaliWalletV2();
 
-  const { constants } = useConstants();
-
-  const { connect, account, chainId, switchToMainnet } = useNEVM();
+  const { connect, account, isExpectedChain, switchToMainnet } = useNEVM();
   const { transfer } = useTransfer();
   const nevmAccount = account ?? transfer.nevmAddress ?? "";
   const hasNevmAccount = nevmAccount !== "";
@@ -55,7 +52,7 @@ const NEVMStepWrapper: React.FC<Props> = ({ children }) => {
     );
   }
 
-  if (chainId !== constants?.chain_id) {
+  if (!isExpectedChain) {
     return (
       <Button variant="contained" onClick={switchToMainnet}>
         Switch to NEVM Network

--- a/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
+++ b/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
@@ -11,6 +11,7 @@ import { useFormContext } from "react-hook-form";
 import { useNevmBalance, useUtxoBalance } from "utils/balance-hooks";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import { useConstants } from "@contexts/useConstants";
+import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
 
 const ErrorMessage = ({ message }: { message: string }) => (
   <Box sx={{ display: "flex", mb: 2 }}>
@@ -25,6 +26,7 @@ export const ConnectValidateStartTransferButton: React.FC<{
   isSaving: boolean;
 }> = ({ isSaving, transfer }) => {
   const { constants } = useConstants();
+  const { isExpectedChain } = useNEVM();
   const {
     watch,
     formState: { errors, isValid },
@@ -64,6 +66,7 @@ export const ConnectValidateStartTransferButton: React.FC<{
     transfer.type === "sys-to-nevm" &&
     sysxBalance.data !== undefined &&
     (sysxBalance.data < MIN_AMOUNT || sysxBalance.data < amount);
+  const isNevmWrongNetwork = Boolean(nevmAddress) && !isExpectedChain;
 
   const isUtxoValid =
     isValidSYSAddress(utxoAddress, constants?.isTestnet ? 5700 : 57) &&
@@ -73,6 +76,7 @@ export const ConnectValidateStartTransferButton: React.FC<{
 
   const isNevmValid =
     isValidEthereumAddress(nevmAddress) &&
+    !isNevmWrongNetwork &&
     (!isNevmNotEnoughGas || foundationFundingAvailable);
   const isAmountValid = errors.amount === undefined;
   const balanceFetched = utxoBalance.isFetched && nevmBalance.isFetched;
@@ -96,6 +100,9 @@ export const ConnectValidateStartTransferButton: React.FC<{
       )}
       {isNevmNotEnoughGas && (
         <ErrorMessage message="NEVM: Not enough funds for gas" />
+      )}
+      {isNevmWrongNetwork && (
+        <ErrorMessage message="NEVM: Wallet must be connected to the NEVM network" />
       )}
       <Button
         sx={{ display: "block" }}

--- a/components/Bridge/WalletSwitch/NEVMConnect.tsx
+++ b/components/Bridge/WalletSwitch/NEVMConnect.tsx
@@ -1,4 +1,4 @@
-import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
+import { useNEVM, MAINNET_CHAIN_ID } from "@contexts/ConnectedWallet/NEVMProvider";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
 import { Alert, Button, Link, Typography } from "@mui/material";
 import WalletSwitchCard from "./Card";
@@ -8,6 +8,7 @@ import { useNevmBalance } from "utils/balance-hooks";
 import { MIN_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
 import { useConnectedWallet } from "@contexts/ConnectedWallet/useConnectedWallet";
+import { useConstants } from "@contexts/useConstants";
 import React from "react";
 
 type NEVMConnectProps = {
@@ -18,7 +19,7 @@ type NEVMConnectProps = {
 const minAmount = MIN_AMOUNT;
 
 const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
-  const { account, connect } = useNEVM();
+  const { account, connect, chainId, switchToMainnet } = useNEVM();
   const { isEnabled } = useFeatureFlags();
   const {
     changeAccount,
@@ -26,6 +27,9 @@ const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
     isEVMInjected,
     switchTo,
   } = usePaliWalletV2();
+  const { constants } = useConstants();
+  const expectedChainId = constants?.chain_id ?? MAINNET_CHAIN_ID;
+  const isWrongChain = Boolean(chainId && chainId !== expectedChainId);
   const balance = useNevmBalance(transfer.nevmAddress);
   const { connectNEVM, nevm } = useConnectedWallet();
 
@@ -47,6 +51,15 @@ const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
   const allowChange = transfer.status === "initialize";
   const hasNevmAddress = Boolean(transfer.nevmAddress);
   
+  // If the address is already set but the user switched to a wrong EVM chain, prompt to switch back
+  if (hasNevmAddress && isWrongChain) {
+    return (
+      <Button variant="contained" onClick={switchToMainnet}>
+        Switch to NEVM Network
+      </Button>
+    );
+  }
+
   // Show the card with the selected address if we have a nevmAddress
   if (hasNevmAddress) {
     let balanceNum = balance.data ?? 0;
@@ -92,6 +105,14 @@ const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
 
   if (!account) {
     return <Button onClick={() => connect()}>Fetch account</Button>;
+  }
+
+  if (isWrongChain) {
+    return (
+      <Button variant="contained" onClick={switchToMainnet}>
+        Switch to NEVM Network
+      </Button>
+    );
   }
 
   return (

--- a/components/Bridge/WalletSwitch/NEVMConnect.tsx
+++ b/components/Bridge/WalletSwitch/NEVMConnect.tsx
@@ -1,4 +1,4 @@
-import { useNEVM, MAINNET_CHAIN_ID } from "@contexts/ConnectedWallet/NEVMProvider";
+import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
 import { Alert, Button, Link, Typography } from "@mui/material";
 import WalletSwitchCard from "./Card";
@@ -8,7 +8,6 @@ import { useNevmBalance } from "utils/balance-hooks";
 import { MIN_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
 import { useConnectedWallet } from "@contexts/ConnectedWallet/useConnectedWallet";
-import { useConstants } from "@contexts/useConstants";
 import React from "react";
 
 type NEVMConnectProps = {
@@ -19,7 +18,7 @@ type NEVMConnectProps = {
 const minAmount = MIN_AMOUNT;
 
 const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
-  const { account, connect, chainId, switchToMainnet } = useNEVM();
+  const { account, connect, isWrongChain, switchToMainnet } = useNEVM();
   const { isEnabled } = useFeatureFlags();
   const {
     changeAccount,
@@ -27,9 +26,6 @@ const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
     isEVMInjected,
     switchTo,
   } = usePaliWalletV2();
-  const { constants } = useConstants();
-  const expectedChainId = constants?.chain_id ?? MAINNET_CHAIN_ID;
-  const isWrongChain = Boolean(chainId && chainId !== expectedChainId);
   const balance = useNevmBalance(transfer.nevmAddress);
   const { connectNEVM, nevm } = useConnectedWallet();
 

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -14,6 +14,9 @@ interface INEVMContext {
   balance?: string;
   isTestnet: boolean;
   chainId?: string;
+  expectedChainId: string;
+  isExpectedChain: boolean;
+  isWrongChain: boolean;
   switchToMainnet: () => void;
   sendTransaction: (transactionConfig: TransactionConfig) => Promise<string>;
   signMessage: (message: string) => Promise<string>;
@@ -142,6 +145,14 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
       refetchOnWindowFocus: true 
     }
   );
+  const expectedChainId = constants?.chain_id ?? MAINNET_CHAIN_ID;
+  const normalizedChainId =
+    typeof chainId.data === "string" ? chainId.data.toLowerCase() : undefined;
+  const normalizedExpectedChainId = expectedChainId.toLowerCase();
+  const isExpectedChain = normalizedChainId === normalizedExpectedChainId;
+  const isWrongChain = Boolean(
+    normalizedChainId && normalizedChainId !== normalizedExpectedChainId
+  );
 
   const sendTransaction = (config: TransactionConfig) => {
     return window.ethereum.request({
@@ -218,6 +229,9 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
         sendTransaction,
         balance: balance.data,
         isTestnet: !!isTestnet,
+        expectedChainId,
+        isExpectedChain,
+        isWrongChain,
         switchToMainnet,
         connect,
         chainId: chainId.isSuccess && chainId.data ? chainId.data : undefined,


### PR DESCRIPTION
Closes #62

The bridge wasn't checking if the user was on the correct EVM chain.
When Pali Wallet was connected to any EVM chain, the bridge would skip the chain validation and allow the user to
proceed with the wrong network.

This fix enforces the NEVM chain check (0x39) in two places:
- Before confirming the NEVM address (pre-set)
- After the address is already set, in case the user switches chains mid-session