### PR TITLE
fix: preserve bridge form state on direction switch

### DIFF
--- a/components/Bridge/StepSwitch.tsx
+++ b/components/Bridge/StepSwitch.tsx
@@ -15,14 +15,22 @@ import BridgeStepGenerateProofs from "./Steps/GenerateProofs";
 import BridgeStepMintSysx from "./Steps/MintSysx";
 import BridgeStepSubmitProofs from "./Steps/SubmitProofs";
 import { useTransfer } from "./context/TransferContext";
+import type { ConnectValidateDraft } from "./Steps/ConnectValidate";
 
-const BridgeStepSwitch = () => {
+type BridgeStepSwitchProps = {
+  onConnectValidateDraftChange?: (draft: ConnectValidateDraft) => void;
+};
+
+const BridgeStepSwitch: React.FC<BridgeStepSwitchProps> = ({
+  onConnectValidateDraftChange,
+}) => {
   const { transfer } = useTransfer();
   if (transfer.type === "nevm-to-sys") {
     if (transfer.status === COMMON_STATUS.INITIALIZE) {
       return (
         <BridgeConnectValidateStep
           successStatus={ETH_TO_SYS_TRANSFER_STATUS.FREEZE_BURN_SYS}
+          onDraftChange={onConnectValidateDraftChange}
         />
       );
     } else if (transfer.status === ETH_TO_SYS_TRANSFER_STATUS.FREEZE_BURN_SYS) {
@@ -86,6 +94,7 @@ const BridgeStepSwitch = () => {
     return (
       <BridgeConnectValidateStep
         successStatus={SYS_TO_ETH_TRANSFER_STATUS.BURN_SYS}
+        onDraftChange={onConnectValidateDraftChange}
       />
     );
   } else if (transfer.status === SYS_TO_ETH_TRANSFER_STATUS.BURN_SYS) {

--- a/components/Bridge/Steps/ConnectValidate.tsx
+++ b/components/Bridge/Steps/ConnectValidate.tsx
@@ -80,35 +80,68 @@ type ConnectValidateFormData = {
   utxoAssetType?: "sys" | "sysx";
 };
 
+export type ConnectValidateDraft = {
+  amount?: number;
+  nevmAddress: string;
+  utxoAddress: string;
+  utxoXpub: string;
+  utxoAssetType?: "sys" | "sysx";
+};
+
 type BridgeConnectValidateStepProps = {
   successStatus: TransferStatus;
+  onDraftChange?: (draft: ConnectValidateDraft) => void;
+};
+
+const parseTransferAmount = (amount: string) => {
+  const parsedAmount = Number(amount);
+
+  return Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : 0.1;
 };
 
 const BridgeConnectValidateStep: React.FC<
   BridgeConnectValidateStepProps
-> = ({ successStatus }) => {
+> = ({ successStatus, onDraftChange }) => {
   const { replace } = useRouter();
   const { transfer, isSaving, saveTransfer } = useTransfer();
   const { isLoading } = usePaliWalletV2();
   const form = useForm<ConnectValidateFormData>({
     mode: "all",
     values: {
-      amount: 0.1,
+      amount: parseTransferAmount(transfer.amount),
       nevmAddress: transfer.nevmAddress || "",
       utxoAddress: transfer.utxoAddress || "",
       utxoXpub: transfer.utxoXpub || "",
       agreedToTerms: false,
-      utxoAssetType: undefined,
+      utxoAssetType: transfer.utxoAssetType,
     },
   });
 
   const { handleSubmit, watch, reset } = form;
 
+  const amount = watch("amount");
   const utxoAddress = watch("utxoAddress");
   const utxoXpub = watch("utxoXpub");
   const utxoAssetType = watch("utxoAssetType");
 
   const nevmAddress = watch("nevmAddress");
+
+  useEffect(() => {
+    onDraftChange?.({
+      amount: Number.isFinite(amount) ? amount : undefined,
+      nevmAddress,
+      utxoAddress,
+      utxoXpub,
+      utxoAssetType,
+    });
+  }, [
+    amount,
+    nevmAddress,
+    onDraftChange,
+    utxoAddress,
+    utxoAssetType,
+    utxoXpub,
+  ]);
 
   // Reset form when transfer ID changes (e.g., starting a new transfer)
   useEffect(() => {

--- a/components/Bridge/Steps/ConnectValidate.tsx
+++ b/components/Bridge/Steps/ConnectValidate.tsx
@@ -99,6 +99,18 @@ const parseTransferAmount = (amount: string) => {
   return Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : 0.1;
 };
 
+const hasDraftFormValues = (
+  amount: string,
+  utxoAssetType?: "sys" | "sysx"
+) => {
+  const parsedAmount = Number(amount);
+
+  return (
+    (Number.isFinite(parsedAmount) && parsedAmount > 0) ||
+    Boolean(utxoAssetType)
+  );
+};
+
 const BridgeConnectValidateStep: React.FC<
   BridgeConnectValidateStepProps
 > = ({ successStatus, onDraftChange }) => {
@@ -145,7 +157,12 @@ const BridgeConnectValidateStep: React.FC<
 
   // Reset form when transfer ID changes (e.g., starting a new transfer)
   useEffect(() => {
-    if (transfer.status === "initialize" && !transfer.nevmAddress && !transfer.utxoAddress) {
+    if (
+      transfer.status === "initialize" &&
+      !transfer.nevmAddress &&
+      !transfer.utxoAddress &&
+      !hasDraftFormValues(transfer.amount, transfer.utxoAssetType)
+    ) {
       reset({
         amount: 0.1,
         nevmAddress: "",
@@ -155,7 +172,15 @@ const BridgeConnectValidateStep: React.FC<
         utxoAssetType: undefined,
       });
     }
-  }, [transfer.id, transfer.status, transfer.nevmAddress, transfer.utxoAddress, reset]);
+  }, [
+    reset,
+    transfer.amount,
+    transfer.id,
+    transfer.nevmAddress,
+    transfer.status,
+    transfer.utxoAddress,
+    transfer.utxoAssetType,
+  ]);
 
   const utxoBalance = useUtxoBalance(utxoXpub);
   const sysxBalance = useUtxoBalance(utxoXpub, {

--- a/components/Bridge/Steps/ConnectValidate/AgreeToTermsCheckbox.tsx
+++ b/components/Bridge/Steps/ConnectValidate/AgreeToTermsCheckbox.tsx
@@ -6,18 +6,29 @@ import {
   Link as MUILink,
 } from "@mui/material";
 import Link from "next/link";
-import { useFormContext } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 
 export const ConnectValidateAgreeToTermsCheckbox = () => {
-  const { register } = useFormContext();
+  const { control } = useFormContext();
   return (
     <Box>
       <FormControlLabel
         control={
-          <Checkbox
-            {...register("agreedToTerms", { required: true })}
-            color="primary"
-          ></Checkbox>
+          <Controller
+            name="agreedToTerms"
+            control={control}
+            rules={{ required: true }}
+            render={({ field }) => (
+              <Checkbox
+                checked={Boolean(field.value)}
+                color="primary"
+                inputRef={field.ref}
+                name={field.name}
+                onBlur={field.onBlur}
+                onChange={(event) => field.onChange(event.target.checked)}
+              />
+            )}
+          />
         }
         label={
           <Typography variant="body1">

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -29,7 +29,7 @@ import {
 import { Web3Provider } from "components/Bridge/context/Web";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
@@ -67,11 +67,20 @@ const createTransfer = (
   utxoAssetType: draft.utxoAssetType,
 });
 
+const isDirectionRoute = (id: unknown): id is TransferType =>
+  id === "sys-to-nevm" || id === "nevm-to-sys";
+
 const BridgePage: NextPage = () => {
   const { query } = useRouter();
   const connectValidateDraft = useRef<Partial<ConnectValidateDraft>>({});
   // Create a new QueryClient when the transfer ID changes to avoid stale data
   const queryClient = useMemo(() => new QueryClient(), [query.id]);
+
+  useEffect(() => {
+    if (!isDirectionRoute(query.id)) {
+      connectValidateDraft.current = {};
+    }
+  }, [query.id]);
 
   const handleConnectValidateDraftChange = useCallback(
     (draft: ConnectValidateDraft) => {
@@ -85,7 +94,7 @@ const BridgePage: NextPage = () => {
 
   const initialTransfer = useMemo(() => {
     const id = query.id;
-    if (id === "sys-to-nevm" || id === "nevm-to-sys") {
+    if (isDirectionRoute(id)) {
       return createTransfer(id, connectValidateDraft.current);
     }
     return {

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -29,7 +29,7 @@ import {
 import { Web3Provider } from "components/Bridge/context/Web";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
@@ -69,29 +69,16 @@ const createTransfer = (
 
 const BridgePage: NextPage = () => {
   const { query } = useRouter();
-  const [connectValidateDraft, setConnectValidateDraft] = useState<
-    Partial<ConnectValidateDraft>
-  >({});
+  const connectValidateDraft = useRef<Partial<ConnectValidateDraft>>({});
   // Create a new QueryClient when the transfer ID changes to avoid stale data
   const queryClient = useMemo(() => new QueryClient(), [query.id]);
 
   const handleConnectValidateDraftChange = useCallback(
     (draft: ConnectValidateDraft) => {
-      setConnectValidateDraft((currentDraft) => {
-        const nextDraft = {
-          ...currentDraft,
-          ...draft,
-        };
-
-        const hasChanges =
-          currentDraft.amount !== nextDraft.amount ||
-          currentDraft.nevmAddress !== nextDraft.nevmAddress ||
-          currentDraft.utxoAddress !== nextDraft.utxoAddress ||
-          currentDraft.utxoXpub !== nextDraft.utxoXpub ||
-          currentDraft.utxoAssetType !== nextDraft.utxoAssetType;
-
-        return hasChanges ? nextDraft : currentDraft;
-      });
+      connectValidateDraft.current = {
+        ...connectValidateDraft.current,
+        ...draft,
+      };
     },
     []
   );
@@ -99,12 +86,12 @@ const BridgePage: NextPage = () => {
   const initialTransfer = useMemo(() => {
     const id = query.id;
     if (id === "sys-to-nevm" || id === "nevm-to-sys") {
-      return createTransfer(id, connectValidateDraft);
+      return createTransfer(id, connectValidateDraft.current);
     }
     return {
       id,
     } as ITransfer;
-  }, [connectValidateDraft, query.id]);
+  }, [query.id]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -20,6 +20,7 @@ import TransferTitle from "components/Bridge/Transfer/Title";
 import BridgeSavingIndicator from "components/Bridge/SavingIndicator";
 import BridgeStepSwitch from "components/Bridge/StepSwitch";
 import BridgeStepper from "components/Bridge/Stepper";
+import type { ConnectValidateDraft } from "components/Bridge/Steps/ConnectValidate";
 import { SyscoinProvider } from "components/Bridge/context/Syscoin";
 import {
   TransferContextProvider,
@@ -28,7 +29,7 @@ import {
 import { Web3Provider } from "components/Bridge/context/Web";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
@@ -45,7 +46,10 @@ const NewTransferButton = () => {
   return <BridgeNewTransferButton />;
 };
 
-const createTransfer = (type: TransferType): ITransfer => ({
+const createTransfer = (
+  type: TransferType,
+  draft: Partial<ConnectValidateDraft> = {}
+): ITransfer => ({
   amount: "0",
   id: `${Date.now()}`,
   type,
@@ -54,22 +58,53 @@ const createTransfer = (type: TransferType): ITransfer => ({
   createdAt: Date.now(),
   version: "v2",
   agreedToTerms: false,
+  ...(draft.amount !== undefined && Number.isFinite(draft.amount)
+    ? { amount: draft.amount.toString() }
+    : {}),
+  nevmAddress: draft.nevmAddress || undefined,
+  utxoAddress: draft.utxoAddress || undefined,
+  utxoXpub: draft.utxoXpub || undefined,
+  utxoAssetType: draft.utxoAssetType,
 });
 
 const BridgePage: NextPage = () => {
   const { query } = useRouter();
+  const [connectValidateDraft, setConnectValidateDraft] = useState<
+    Partial<ConnectValidateDraft>
+  >({});
   // Create a new QueryClient when the transfer ID changes to avoid stale data
   const queryClient = useMemo(() => new QueryClient(), [query.id]);
+
+  const handleConnectValidateDraftChange = useCallback(
+    (draft: ConnectValidateDraft) => {
+      setConnectValidateDraft((currentDraft) => {
+        const nextDraft = {
+          ...currentDraft,
+          ...draft,
+        };
+
+        const hasChanges =
+          currentDraft.amount !== nextDraft.amount ||
+          currentDraft.nevmAddress !== nextDraft.nevmAddress ||
+          currentDraft.utxoAddress !== nextDraft.utxoAddress ||
+          currentDraft.utxoXpub !== nextDraft.utxoXpub ||
+          currentDraft.utxoAssetType !== nextDraft.utxoAssetType;
+
+        return hasChanges ? nextDraft : currentDraft;
+      });
+    },
+    []
+  );
 
   const initialTransfer = useMemo(() => {
     const id = query.id;
     if (id === "sys-to-nevm" || id === "nevm-to-sys") {
-      return createTransfer(id);
+      return createTransfer(id, connectValidateDraft);
     }
     return {
       id,
     } as ITransfer;
-  }, [query.id]);
+  }, [connectValidateDraft, query.id]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -112,7 +147,11 @@ const BridgePage: NextPage = () => {
                         }}
                       >
                         <CardContent>
-                          <BridgeStepSwitch />
+                          <BridgeStepSwitch
+                            onConnectValidateDraftChange={
+                              handleConnectValidateDraftChange
+                            }
+                          />
                           <BridgeSavingIndicator />
                         </CardContent>
                       </Card>

--- a/utils/syscoin-urls.test.ts
+++ b/utils/syscoin-urls.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@jest/globals";
 import {
   MAINNET_BLOCKBOOK_URL,
   resolveUtxoBlockbookUrl,


### PR DESCRIPTION
## Summary
- Preserve the initialize-step bridge draft when switching between Syscoin UTXO -> NEVM and NEVM -> UTXO directions.
- Control the terms checkbox through React Hook Form so visual checked state and validation state stay in sync.
- Import Jest globals explicitly in the Blockbook URL resolver test so the repo type check passes.

## Test plan
- yarn --ignore-engines lint
- yarn --ignore-engines tsc --noEmit
- yarn --ignore-engines jest utils/syscoin-urls.test.ts --runInBand

Fixes #63

Made with [Cursor](https://cursor.com)