### PR TITLE
Pass coinbase same-depth proof to relayTx

### DIFF
--- a/components/Bridge/hooks/useSubmitProof.tsx
+++ b/components/Bridge/hooks/useSubmitProof.tsx
@@ -20,10 +20,18 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
     }
+    if (!proof.coinbase) {
+      throw new Error("SPV proof missing coinbase (update syscoingetspvproof / blockbook)");
+    }
     const txBytes = `0x${proof.transaction}`;
     const txIndex = proof.index;
     const merkleProof = getProof(proof.siblings, txIndex);
     merkleProof.sibling = merkleProof.sibling.map((sibling) => `0x${sibling}`);
+    const coinbaseBytes = `0x${proof.coinbase}`;
+    const coinbaseProof = getProof(proof.siblings, 0);
+    coinbaseProof.sibling = coinbaseProof.sibling.map(
+      (sibling) => `0x${sibling}`
+    );
     const syscoinBlockheader = `0x${proof.header}`;
 
     const method = relayContract.methods.relayTx(
@@ -31,7 +39,9 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
       txBytes,
       txIndex,
       merkleProof.sibling,
-      syscoinBlockheader
+      syscoinBlockheader,
+      coinbaseBytes,
+      coinbaseProof.sibling
     );
 
     const gasPrice = await web3.eth.getGasPrice();

--- a/contexts/Transfer/functions/sysToNevm.ts
+++ b/contexts/Transfer/functions/sysToNevm.ts
@@ -164,10 +164,20 @@ const runWithSysToNevmStateMachine = async (
       if (!nevmBlock) {
         throw new Error("NEVM block not found: " + proof.nevm_blockhash);
       }
+      if (!proof.coinbase) {
+        throw new Error(
+          "SPV proof missing coinbase (update syscoingetspvproof / blockbook)"
+        );
+      }
       const txBytes = `0x${proof.transaction}`;
       const txIndex = proof.index;
       const merkleProof = getProof(proof.siblings, txIndex);
       merkleProof.sibling = merkleProof.sibling.map(
+        (sibling) => `0x${sibling}`
+      );
+      const coinbaseBytes = `0x${proof.coinbase}`;
+      const coinbaseProof = getProof(proof.siblings, 0);
+      coinbaseProof.sibling = coinbaseProof.sibling.map(
         (sibling) => `0x${sibling}`
       );
       const syscoinBlockheader = `0x${proof.header}`;
@@ -177,7 +187,9 @@ const runWithSysToNevmStateMachine = async (
         txBytes,
         txIndex,
         merkleProof.sibling,
-        syscoinBlockheader
+        syscoinBlockheader,
+        coinbaseBytes,
+        coinbaseProof.sibling
       );
 
       const gasPrice = await web3.eth.getGasPrice();

--- a/contexts/Transfer/relay-abi.ts
+++ b/contexts/Transfer/relay-abi.ts
@@ -28,6 +28,16 @@ export const relayAbi: AbiItem[] = [
         name: "_syscoinBlockHeader",
         type: "bytes",
       },
+      {
+        internalType: "bytes",
+        name: "_coinbaseTxBytes",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256[]",
+        name: "_coinbaseSiblings",
+        type: "uint256[]",
+      },
     ],
     name: "relayTx",
     outputs: [

--- a/contexts/Transfer/syscoinjs-lib.d.ts
+++ b/contexts/Transfer/syscoinjs-lib.d.ts
@@ -1,6 +1,8 @@
 declare module "syscoinjs-lib" {
   interface SPVProof {
     transaction: string;
+    /** Witness-stripped coinbase hex for same-depth Merkle checks */
+    coinbase: string;
     blockhash: string;
     header: string;
     siblings: string[];

--- a/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
+++ b/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
@@ -46,10 +46,20 @@ const handler: NextApiHandler = async (
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
     }
+    if (!proof.coinbase) {
+      throw new Error(
+        "SPV proof missing coinbase (update syscoingetspvproof / blockbook)"
+      );
+    }
     const txBytes = `0x${proof.transaction}`;
     const txIndex = proof.index;
     const merkleProof = getProof(proof.siblings, txIndex);
     merkleProof.sibling = merkleProof.sibling.map((sibling) => `0x${sibling}`);
+    const coinbaseBytes = `0x${proof.coinbase}`;
+    const coinbaseProof = getProof(proof.siblings, 0);
+    coinbaseProof.sibling = coinbaseProof.sibling.map(
+      (sibling) => `0x${sibling}`
+    );
     const syscoinBlockheader = `0x${proof.header}`;
 
     const method = relayContract.methods.relayTx(
@@ -57,7 +67,9 @@ const handler: NextApiHandler = async (
       txBytes,
       txIndex,
       merkleProof.sibling,
-      syscoinBlockheader
+      syscoinBlockheader,
+      coinbaseBytes,
+      coinbaseProof.sibling
     );
 
     const encoded = method.encodeABI();


### PR DESCRIPTION
## Summary
- Update `relayTx` ABI with `_coinbaseTxBytes` / `_coinbaseSiblings`.
- Client + sponsored submit paths derive coinbase Merkle siblings via `getProof(siblings, 0)` and require `proof.coinbase` from Core/Blockbook.

Pairs with:
- https://github.com/syscoin/sysethereum-contracts/pull/95
- https://github.com/syscoin/syscoin/pull/597

## Test plan
- [ ] SYS→NEVM submit proof succeeds against upgraded relay when SPV JSON includes `coinbase`
- [ ] Missing `coinbase` fails with a clear error (Core/Blockbook not updated yet)
- [ ] Sponsored `signed-submit-proofs-tx` encodes the new args


Made with [Cursor](https://cursor.com)