### PR TITLE
Fix foundation sponsor nonce recovery

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -31,5 +31,7 @@ jobs:
         run: yarn
       - name: Lint Code
         run: yarn lint
+      - name: Run Tests
+        run: yarn test --runInBand
       - name: Build Application
         run: yarn build

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ Sponsorship is rate-limited by client IP, destination UTXO address, and source N
 
 Sponsor signing keys are configured through deployment secrets/env vars. MongoDB stores sponsorship usage, reservations, and rate-limit state only; it does not store sponsor private keys.
 
+NEVM sponsorship is server-broadcast: the backend durably stores each signed
+transaction, broadcasts it in nonce order, and returns only the accepted hash
+to the browser. Pending raw transactions are replayed by later requests before
+another nonce is signed.
+
+#### Foundation-funded V2 cutover
+
+Treat enabling `FOUNDATION_FUNDED=true` as an atomic V2 backend cutover:
+
+1. Keep funding disabled while all pre-V2/older backend instances are stopped.
+2. Reconcile every legacy signed sponsor row that lacks `action` or
+   `sourceTxHash`. Confirm/broadcast or replace its nonce as appropriate, then
+   archive the row; do not copy it into the V2 sponsor namespace.
+3. Deploy the V2 backend to every instance and allow its MongoDB indexes to be
+   created.
+4. Enable foundation funding only after all instances run the same V2 sponsor
+   protocol.
+
+Startup fails closed when foundation funding is enabled while an unreconciled
+legacy signed row remains. A rolling deployment with old sponsor-signing
+instances is unsupported.
+
 ## How to run
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -56,12 +56,17 @@ another nonce is signed.
 Treat enabling `FOUNDATION_FUNDED=true` as an atomic V2 backend cutover:
 
 1. Keep funding disabled while all pre-V2/older backend instances are stopped.
-2. Reconcile every legacy signed sponsor row that lacks `action` or
+2. Configure `NEVM_V2_ACTIVATION_BLOCK` to the immutable first NEVM block
+   eligible for V2 claim-gas sponsorship. Funding fails closed if it is missing
+   or invalid.
+3. Reconcile every legacy signed sponsor row that lacks `action` or
    `sourceTxHash`. Confirm/broadcast or replace its nonce as appropriate, then
    archive the row; do not copy it into the V2 sponsor namespace.
-3. Deploy the V2 backend to every instance and allow its MongoDB indexes to be
-   created.
-4. Enable foundation funding only after all instances run the same V2 sponsor
+4. Deploy the V2 backend and frontend together to every instance and allow its
+   MongoDB indexes to be created. New transfers receive a per-transfer write
+   capability; pre-cutover rows without one are intentionally read-only through
+   the public API.
+5. Enable foundation funding only after all instances run the same V2 sponsor
    protocol.
 
 Startup fails closed when foundation funding is enabled while an unreconciled
@@ -145,6 +150,7 @@ docker build -t syscoin/bridge .
 | `SYS5_ENABLED`                  | Enable Sys5 features                           | true    |
 | `PALI_V2_NEVM_ENABLED`          | Enable Pali V2 NEVM features                    | true    |
 | `FOUNDATION_FUNDED`             | Enable sponsored claim gas for destination-side bridge completion | false   |
+| `NEVM_V2_ACTIVATION_BLOCK`      | First NEVM block eligible for V2 foundation-funded claim gas; required when funding is enabled |         |
 | `NEVM_SPONSOR_PRIVATE_KEY`      | Private key for the NEVM sponsor wallet used to sign sponsored `submit-proofs` transactions |         |
 | `UTXO_SPONSOR_ADDRESS`          | Syscoin UTXO sponsor address used for NEVM-to-UTXO claim gas funding |         |
 | `UTXO_SPONSOR_WIF`              | WIF private key for the UTXO sponsor address    |         |

--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ Treat enabling `FOUNDATION_FUNDED=true` as an atomic V2 backend cutover:
 3. Reconcile every legacy signed sponsor row that lacks `action` or
    `sourceTxHash`. Confirm/broadcast or replace its nonce as appropriate, then
    archive the row; do not copy it into the V2 sponsor namespace.
-4. Deploy the V2 backend and frontend together to every instance and allow its
+4. Reconcile duplicate historical transfer IDs. Startup checks for duplicates
+   and synchronously creates the unique transfer-ID index before serving public
+   writes.
+5. Deploy the V2 backend and frontend together to every instance and allow its
    MongoDB indexes to be created. New transfers receive a per-transfer write
    capability; pre-cutover rows without one are intentionally read-only through
    the public API.
-5. Enable foundation funding only after all instances run the same V2 sponsor
+6. Enable foundation funding only after all instances run the same V2 sponsor
    protocol.
 
 Startup fails closed when foundation funding is enabled while an unreconciled

--- a/api/routes/__tests__/sponsor-claim-gas.test.ts
+++ b/api/routes/__tests__/sponsor-claim-gas.test.ts
@@ -1,0 +1,163 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const mockGetTransaction = jest.fn<any>();
+const mockGetTransactionReceipt = jest.fn<any>();
+const mockDecodeLog = jest.fn<any>();
+
+jest.mock("@constants", () => ({
+  ERC20_MANAGER_CONTRACT_ADDRESS: "0x1111111111111111111111111111111111111111",
+  MIN_AMOUNT: 1,
+}));
+jest.mock("@contexts/Transfer/constants", () => ({
+  SYSX_ASSET_GUID: "123",
+}));
+jest.mock("@contexts/Transfer/abi/SyscoinERC20Manager", () => [
+  {
+    type: "event",
+    name: "TokenFreeze",
+    inputs: [
+      { indexed: true, name: "assetGuid", type: "uint256" },
+      { indexed: true, name: "from", type: "address" },
+      { indexed: false, name: "satoshiValue", type: "uint256" },
+      { indexed: false, name: "syscoinAddr", type: "string" },
+    ],
+  },
+]);
+jest.mock("api/services/sponsor-wallet", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("api/services/transfer", () => ({
+  TransferService: jest.fn(),
+}));
+jest.mock("lib/mongodb", () => jest.fn());
+jest.mock("models/sponsor-rate-limit", () => ({
+  __esModule: true,
+  default: { updateOne: jest.fn() },
+}));
+jest.mock("utils/get-web3", () => ({
+  __esModule: true,
+  default: {
+    eth: {
+      abi: {
+        decodeLog: mockDecodeLog,
+        encodeEventSignature: jest.fn(() => "0xtokenfreeze"),
+      },
+      getTransaction: mockGetTransaction,
+      getTransactionReceipt: mockGetTransactionReceipt,
+    },
+  },
+}));
+
+import { ETH_TO_SYS_TRANSFER_STATUS } from "@contexts/Transfer/types";
+import { assertClaimGasEligible } from "pages/api/transfer/[id]/sponsor-claim-gas";
+
+const managerAddress = "0x1111111111111111111111111111111111111111";
+const nevmAddress = "0x2222222222222222222222222222222222222222";
+const freezeBurnTxHash = `0x${"ab".repeat(32)}`;
+
+const transfer = {
+  id: "transfer-v2",
+  type: "nevm-to-sys" as const,
+  status: ETH_TO_SYS_TRANSFER_STATUS.CONFIRM_FREEZE_BURN_SYS,
+  amount: "1",
+  logs: [
+    {
+      status: ETH_TO_SYS_TRANSFER_STATUS.CONFIRM_FREEZE_BURN_SYS,
+      payload: {
+        message: "confirmed",
+        data: { transactionHash: freezeBurnTxHash },
+      },
+      date: 1,
+    },
+  ],
+  createdAt: 1,
+  updatedAt: 1,
+  utxoAddress: "sys1destination",
+  nevmAddress,
+  version: "v2" as const,
+  agreedToTerms: true,
+};
+
+describe("foundation claim-gas V2 activation eligibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEVM_V2_ACTIVATION_BLOCK = "100";
+    mockGetTransaction.mockResolvedValue({
+      to: managerAddress,
+      from: nevmAddress,
+      value: "1000000000000000000",
+    });
+    mockGetTransactionReceipt.mockResolvedValue({
+      blockNumber: 99,
+      status: true,
+      to: managerAddress,
+      logs: [
+        {
+          address: managerAddress,
+          topics: [
+            "0xtokenfreeze",
+            "0x7b",
+            `0x${"0".repeat(24)}${nevmAddress.slice(2)}`,
+          ],
+          data: "0x",
+        },
+      ],
+    });
+    mockDecodeLog.mockReturnValue({
+      satoshiValue: "100000000",
+      syscoinAddr: "sys1destination",
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.NEVM_V2_ACTIVATION_BLOCK;
+  });
+
+  it("rejects a genuine pre-activation TokenFreeze even when the row says v2", async () => {
+    await expect(assertClaimGasEligible(transfer)).rejects.toThrow(
+      "before the V2 activation block"
+    );
+  });
+
+  it("accepts a matching event at the activation block regardless of its stored label", async () => {
+    mockGetTransactionReceipt.mockResolvedValue({
+      blockNumber: 100,
+      status: true,
+      to: managerAddress,
+      logs: [
+        {
+          address: managerAddress,
+          topics: [
+            "0xtokenfreeze",
+            "0x7b",
+            `0x${"0".repeat(24)}${nevmAddress.slice(2)}`,
+          ],
+          data: "0x",
+        },
+      ],
+    });
+
+    await expect(
+      assertClaimGasEligible({ ...transfer, version: "v1" })
+    ).resolves.toEqual({
+      blockNumber: 100,
+      transactionHash: freezeBurnTxHash,
+    });
+  });
+
+  it("fails closed when the activation block is unconfigured", async () => {
+    delete process.env.NEVM_V2_ACTIVATION_BLOCK;
+
+    await expect(assertClaimGasEligible(transfer)).rejects.toThrow(
+      "NEVM V2 activation block is not configured"
+    );
+  });
+});

--- a/api/routes/__tests__/transfer-patch.test.ts
+++ b/api/routes/__tests__/transfer-patch.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockUpsertTransfer = jest.fn<any>();
+
+jest.mock("api/services/transfer", () => ({
+  TransferService: jest.fn().mockImplementation(() => ({
+    getTransfer: jest.fn(),
+    upsertTransfer: mockUpsertTransfer,
+  })),
+}));
+jest.mock("lib/mongodb", () => jest.fn());
+jest.mock("utils/api/cors", () => ({
+  applyApiCors: jest.fn(() => false),
+}));
+
+import { NextApiRequest, NextApiResponse } from "next";
+import { patchRequest } from "pages/api/transfer/[id]";
+
+const createResponse = () => {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+describe("transfer PATCH binding", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpsertTransfer.mockResolvedValue({});
+  });
+
+  it("rejects a body that targets a different transfer than the URL", async () => {
+    const request = {
+      query: { id: "victim-transfer" },
+      body: { id: "attacker-transfer" },
+      headers: {},
+    } as unknown as NextApiRequest;
+    const response = createResponse();
+
+    await patchRequest(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(mockUpsertTransfer).not.toHaveBeenCalled();
+  });
+});

--- a/api/services/__tests__/sponsor-proof.test.ts
+++ b/api/services/__tests__/sponsor-proof.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockFetchBackendSPVProof = jest.fn<any>();
+
+jest.mock("syscoinjs-lib", () => ({
+  utils: {
+    fetchBackendSPVProof: mockFetchBackendSPVProof,
+  },
+}));
+
+import { SPVProof } from "syscoinjs-lib";
+import { getCanonicalChainLockedProof } from "../sponsor-proof";
+import { syscoinTxIdFromWitnessStrippedHex } from "utils/syscoin-txid";
+
+const transaction = "01000000";
+const submittedProof = {
+  transaction,
+  chainlock: true,
+} as SPVProof;
+
+describe("canonical sponsored SPV proof finality", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("ignores a client-supplied finality label and rejects a non-ChainLocked backend proof", async () => {
+    mockFetchBackendSPVProof.mockResolvedValue({
+      result: { ...submittedProof, chainlock: false },
+    });
+
+    await expect(
+      getCanonicalChainLockedProof(submittedProof)
+    ).rejects.toThrow("Source transaction is not ChainLocked");
+  });
+
+  it("returns a server-fetched ChainLocked proof for the same source transaction", async () => {
+    const canonicalProof = {
+      ...submittedProof,
+      blockhash: "canonical-block",
+    };
+    mockFetchBackendSPVProof.mockResolvedValue({ result: canonicalProof });
+
+    await expect(getCanonicalChainLockedProof(submittedProof)).resolves.toEqual({
+      proof: canonicalProof,
+      sourceTxHash: syscoinTxIdFromWitnessStrippedHex(transaction),
+    });
+  });
+
+  it("rejects a backend response for a different transaction", async () => {
+    mockFetchBackendSPVProof.mockResolvedValue({
+      result: { ...submittedProof, transaction: "02000000" },
+    });
+
+    await expect(
+      getCanonicalChainLockedProof(submittedProof)
+    ).rejects.toThrow("does not match the source transaction");
+  });
+});

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -672,6 +672,65 @@ describe("SponsorWalletService", () => {
       );
     });
 
+    it("recovers and broadcasts a committed duplicate that wins the placeholder race", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn();
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      const committedDuplicate = {
+        _id: "duplicate-committed-id",
+        transferId: "transfer-duplicate",
+        action: "submit-proofs",
+        sourceTxHash: "duplicate-source",
+        walletId: "0xSponsor",
+        status: "pending",
+        transaction: {
+          hash: "0xduplicate-hash",
+          rawData: "0xduplicate-raw",
+          nonce: 3,
+        },
+      };
+      SponsorWalletTransactionsMock.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(committedDuplicate);
+      SponsorWalletTransactionsMock.mockImplementationOnce(function (
+        this: any,
+        data: any
+      ) {
+        Object.assign(this, data);
+        this.save = jest.fn<any>().mockRejectedValue({ code: 11000 });
+      });
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([committedDuplicate]),
+      });
+      mockWeb3.eth.getTransactionCount
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(4);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xduplicate-hash")
+      );
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-duplicate",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "duplicate-source"
+        )
+      ).resolves.toMatchObject({
+        transaction: { hash: "0xduplicate-hash" },
+      });
+
+      expect(signTransaction).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.estimateGas).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith(
+        "0xduplicate-raw"
+      );
+    });
+
     it("keeps a durable signed row pending when broadcast fails", async () => {
       process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
       const broadcastError = new Error("RPC unavailable");
@@ -1065,6 +1124,10 @@ describe("SponsorWalletService", () => {
         "unsigned-psbt",
         "sponsor-wif"
       );
+      expect(createTransaction.mock.invocationCallOrder[0]).toBeLessThan(
+        SponsorWalletTransactionsMock.findOneAndUpdate.mock
+          .invocationCallOrder[0]
+      );
       expect(
         SponsorWalletTransactionsMock.findOneAndUpdate.mock
           .invocationCallOrder[0]
@@ -1119,6 +1182,71 @@ describe("SponsorWalletService", () => {
       );
       expect(SponsorUtxoReservationMock.deleteOne).toHaveBeenCalledWith({
         key: "small-utxo:1",
+        status: "reserved",
+      });
+    });
+
+    it("releases the reservation when UTXO construction fails before broadcast", async () => {
+      process.env.UTXO_SPONSOR_ADDRESS = "sys1sponsor";
+      process.env.UTXO_SPONSOR_WIF = "sponsor-wif";
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorUtxoReservationMock.create.mockResolvedValue({});
+      SponsorUtxoReservationMock.deleteOne.mockResolvedValue({
+        deletedCount: 1,
+      });
+      (global.fetch as jest.Mock<any>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ balance: "0" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ balance: "0" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              { txid: "construction-utxo", vout: 0, value: "1000000" },
+            ]),
+        });
+      const constructionError = new Error("Unable to build PSBT");
+      const createTransaction = jest.fn(() =>
+        Promise.reject(constructionError)
+      );
+      const signAndSendWithWIF = jest.fn();
+      SyscoinMock.mockImplementation(() => ({
+        createTransaction,
+        signAndSendWithWIF,
+      }));
+
+      const service = new SponsorWalletService();
+
+      await expect(service.sponsorUtxoClaimGas(transfer)).rejects.toThrow(
+        "Unable to build PSBT"
+      );
+
+      expect(signAndSendWithWIF).not.toHaveBeenCalled();
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate
+      ).not.toHaveBeenCalled();
+      expect(SponsorWalletTransactionsMock.updateOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: "placeholder-id",
+          reservationOwner: expect.any(String),
+          "transaction.hash": { $exists: false },
+        }),
+        {
+          $set: { status: "failed" },
+          $unset: {
+            reservationOwner: "",
+            reservationExpiresAt: "",
+            reservationPhase: "",
+          },
+        }
+      );
+      expect(SponsorUtxoReservationMock.deleteOne).toHaveBeenCalledWith({
+        key: "construction-utxo:0",
         status: "reserved",
       });
     });

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -633,7 +633,7 @@ describe("SponsorWalletService", () => {
     });
 
     it("preserves a successful existing sponsorship without rebroadcasting it", async () => {
-      SponsorWalletTransactionsMock.findOne.mockResolvedValue({
+      const successfulTransaction = {
         _id: "successful-id",
         transferId: "transfer-successful",
         action: "submit-proofs",
@@ -645,11 +645,18 @@ describe("SponsorWalletService", () => {
           rawData: "0xsuccessful-raw",
           nonce: 1,
         },
-      });
+      };
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(
+        successfulTransaction
+      );
       SponsorWalletTransactionsMock.find.mockReturnValue({
-        sort: () => Promise.resolve([]),
+        sort: () => Promise.resolve([successfulTransaction]),
       });
       mockWeb3.eth.getTransactionCount.mockResolvedValue(2);
+      mockWeb3.eth.getTransaction.mockResolvedValue({
+        hash: "0xsuccessful",
+        nonce: 1,
+      });
       const service = new SponsorWalletService();
 
       await expect(
@@ -665,11 +672,64 @@ describe("SponsorWalletService", () => {
       });
 
       expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.getTransaction).toHaveBeenCalledWith("0xsuccessful");
       expect(SponsorWalletTransactionsMock.updateOne).not.toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           $set: expect.objectContaining({ status: "pending" }),
         })
+      );
+    });
+
+    it("replays a successful row when the RPC pending nonce rolls back to it", async () => {
+      const successfulTransaction = {
+        _id: "reorged-success-id",
+        transferId: "transfer-reorged-success",
+        action: "submit-proofs",
+        sourceTxHash: "reorged-success-source",
+        walletId: "0xSponsor",
+        status: "success",
+        transaction: {
+          hash: "0xreorged-success",
+          rawData: "0xreorged-success-raw",
+          nonce: 1,
+        },
+      };
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(
+        successfulTransaction
+      );
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([successfulTransaction]),
+      });
+      mockWeb3.eth.getTransactionCount
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(2);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xreorged-success")
+      );
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-reorged-success",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "reorged-success-source"
+        )
+      ).resolves.toMatchObject({
+        status: "success",
+        transaction: { hash: "0xreorged-success" },
+      });
+
+      expect(SponsorWalletTransactionsMock.find).toHaveBeenCalledWith({
+        action: "submit-proofs",
+        walletId: "0xSponsor",
+        sourceTxHash: { $type: "string" },
+        "transaction.rawData": { $type: "string" },
+        "transaction.nonce": { $type: "number" },
+      });
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith(
+        "0xreorged-success-raw"
       );
     });
 

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -10,7 +10,9 @@ const mockWeb3 = {
     getGasPrice: jest.fn<any>(),
     estimateGas: jest.fn<any>(),
     getTransactionCount: jest.fn<any>(),
+    getTransaction: jest.fn<any>(),
     getTransactionReceipt: jest.fn<any>(),
+    sendSignedTransaction: jest.fn<any>(),
   },
   utils: {
     fromWei: jest.fn(),
@@ -26,10 +28,13 @@ jest.mock("utils/get-web3", () => ({
 jest.mock("models/sponsor-wallet-transactions", () => {
   const Model: any = jest.fn(function (this: any, data: any) {
     Object.assign(this, data);
+    this._id = this._id ?? "placeholder-id";
     this.save = jest.fn<any>().mockResolvedValue(this);
   });
   Model.findOne = jest.fn();
   Model.findOneAndUpdate = jest.fn();
+  Model.updateOne = jest.fn();
+  Model.countDocuments = jest.fn();
   Model.find = jest.fn();
   Model.aggregate = jest.fn();
   return {
@@ -83,6 +88,34 @@ const SponsorUtxoReservationMock = SponsorUtxoReservation as any;
 const SyscoinMock = syscoin as jest.Mock;
 const fetchBackendRawTxMock = syscoinUtils.fetchBackendRawTx as jest.Mock<any>;
 
+const successfulBroadcast = (hash: string) => {
+  const promiEvent = {
+    once: jest.fn((event: string, listener: (value: string) => void) => {
+      if (event === "transactionHash") {
+        Promise.resolve().then(() => listener(hash));
+      }
+      return promiEvent;
+    }),
+    on: jest.fn(() => promiEvent),
+    catch: jest.fn(() => promiEvent),
+  };
+  return promiEvent;
+};
+
+const failedBroadcast = (error: Error) => {
+  const promiEvent = {
+    once: jest.fn(() => promiEvent),
+    on: jest.fn((event: string, listener: (value: Error) => void) => {
+      if (event === "error") {
+        Promise.resolve().then(() => listener(error));
+      }
+      return promiEvent;
+    }),
+    catch: jest.fn(() => promiEvent),
+  };
+  return promiEvent;
+};
+
 const transfer: ITransfer = {
   id: "transfer-1",
   type: "nevm-to-sys",
@@ -100,9 +133,26 @@ const transfer: ITransfer = {
 describe("SponsorWalletService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWeb3.eth.accounts.privateKeyToAccount.mockReset();
+    mockWeb3.eth.getGasPrice.mockReset();
+    mockWeb3.eth.estimateGas.mockReset();
+    mockWeb3.eth.getTransactionCount.mockReset();
+    mockWeb3.eth.getTransaction.mockReset();
+    mockWeb3.eth.getTransactionReceipt.mockReset();
+    mockWeb3.eth.sendSignedTransaction.mockReset();
+    SponsorWalletTransactionsMock.findOne.mockReset();
+    SponsorWalletTransactionsMock.findOneAndUpdate.mockReset();
+    SponsorWalletTransactionsMock.updateOne.mockReset();
+    SponsorWalletTransactionsMock.countDocuments.mockReset();
+    SponsorWalletTransactionsMock.find.mockReset();
+    SponsorWalletTransactionsMock.countDocuments.mockResolvedValue(0);
+    SponsorWalletTransactionsMock.updateOne.mockResolvedValue({
+      modifiedCount: 1,
+    });
     delete process.env.NEVM_SPONSOR_PRIVATE_KEY;
     delete process.env.UTXO_SPONSOR_ADDRESS;
     delete process.env.UTXO_SPONSOR_WIF;
+    delete process.env.FOUNDATION_FUNDED;
     global.fetch = jest.fn() as any;
   });
 
@@ -146,11 +196,24 @@ describe("SponsorWalletService", () => {
       mockWeb3.eth.getTransactionCount.mockResolvedValue(3);
       mockWeb3.eth.getGasPrice.mockResolvedValue("100");
       mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xhash")
+      );
       SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
       SponsorWalletTransactionsMock.find.mockReturnValue({
-        sort: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        sort: () => Promise.resolve([]),
+      });
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue({
+        walletId: "0xSponsor",
+        sourceTxHash:
+          "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+        status: "pending",
+        transaction: {
+          hash: "0xhash",
+          rawData: "0xsigned",
+          nonce: 3,
+          confirmedHash: "",
+        },
       });
       const service = new SponsorWalletService();
 
@@ -186,6 +249,198 @@ describe("SponsorWalletService", () => {
           nonce: 3,
         })
       );
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith(
+        "0xsigned"
+      );
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate.mock
+          .invocationCallOrder[0]
+      ).toBeLessThan(
+        mockWeb3.eth.sendSignedTransaction.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("broadcasts a durable lower nonce before signing the next sponsorship", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn(() =>
+        Promise.resolve({
+          rawTransaction: "0xnext-raw",
+          transactionHash: "0xnext-hash",
+        })
+      );
+      const storedTransaction = {
+        _id: "stored-id",
+        action: "submit-proofs",
+        walletId: "0xSponsor",
+        sourceTxHash: "stored-source",
+        status: "failed",
+        transaction: {
+          hash: "0xstored-hash",
+          rawData: "0xstored-raw",
+          nonce: 3,
+          confirmedHash: "",
+        },
+      };
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(4);
+      mockWeb3.eth.getGasPrice.mockResolvedValue("100");
+      mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation((raw: string) =>
+        successfulBroadcast(
+          raw === "0xstored-raw" ? "0xstored-hash" : "0xnext-hash"
+        )
+      );
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([storedTransaction]),
+      });
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue({
+        _id: "next-id",
+        action: "submit-proofs",
+        walletId: "0xSponsor",
+        sourceTxHash: "next-source",
+        status: "pending",
+        transaction: {
+          hash: "0xnext-hash",
+          rawData: "0xnext-raw",
+          nonce: 4,
+          confirmedHash: "",
+        },
+      });
+      const service = new SponsorWalletService();
+
+      await service.sponsorTransaction(
+        "transfer-2",
+        { to: "0xRelay", data: "0xdata", value: 0 },
+        "submit-proofs",
+        "next-source"
+      );
+
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenNthCalledWith(
+        1,
+        "0xstored-raw"
+      );
+      expect(signTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ nonce: 4 })
+      );
+      expect(
+        mockWeb3.eth.sendSignedTransaction.mock.invocationCallOrder[0]
+      ).toBeLessThan(signTransaction.mock.invocationCallOrder[0]);
+    });
+
+    it("fails closed instead of signing across a durable nonce gap", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn();
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(3);
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () =>
+          Promise.resolve([
+            {
+              _id: "gap-id",
+              action: "submit-proofs",
+              walletId: "0xSponsor",
+              sourceTxHash: "gap-source",
+              status: "pending",
+              transaction: {
+                hash: "0xgap-hash",
+                rawData: "0xgap-raw",
+                nonce: 4,
+                confirmedHash: "",
+              },
+            },
+          ]),
+      });
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-gap",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "new-source"
+        )
+      ).rejects.toThrow(
+        "Sponsor nonce recovery blocked: missing durable transaction for nonce 3"
+      );
+      expect(signTransaction).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
+    });
+
+    it("does not broadcast after a stale reservation owner loses its fence", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn(() =>
+        Promise.resolve({
+          rawTransaction: "0xfenced-raw",
+          transactionHash: "0xfenced-hash",
+        })
+      );
+      const stalePlaceholder: any = {
+        _id: "stale-fence-id",
+        transferId: "transfer-fence",
+        action: "submit-proofs",
+        sourceTxHash: "fence-source",
+        walletId: "0xSponsor",
+        status: "pending",
+        updatedAt: new Date(Date.now() - 10 * 60_000),
+        transaction: {},
+      };
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(3);
+      mockWeb3.eth.getGasPrice.mockResolvedValue("100");
+      mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xfenced-hash")
+      );
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(stalePlaceholder);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([]),
+      });
+      SponsorWalletTransactionsMock.findOneAndUpdate
+        .mockImplementationOnce((_query: any, update: any) => {
+          stalePlaceholder.reservationOwner = update.$set.reservationOwner;
+          stalePlaceholder.reservationExpiresAt =
+            update.$set.reservationExpiresAt;
+          return Promise.resolve(stalePlaceholder);
+        })
+        .mockResolvedValueOnce(null);
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-fence",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "fence-source"
+        )
+      ).rejects.toThrow("Sponsorship is already in progress");
+
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate
+      ).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          _id: "stale-fence-id",
+          reservationOwner: stalePlaceholder.reservationOwner,
+          reservationExpiresAt: { $gt: expect.any(Date) },
+        }),
+        expect.any(Object),
+        { new: true }
+      );
+      expect(signTransaction).toHaveBeenCalledTimes(1);
+      expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
     });
 
     it("returns an existing sponsorship for the same source tx under another transferId", async () => {
@@ -196,12 +451,17 @@ describe("SponsorWalletService", () => {
         signTransaction,
       });
       SponsorWalletTransactionsMock.findOne.mockResolvedValue({
+        _id: "existing-id",
         transferId: "transfer-alias-a",
         action: "submit-proofs",
         sourceTxHash: "deadbeef",
+        walletId: "0xSponsor",
         status: "pending",
         transaction: { hash: "0xalready", rawData: "0xraw", nonce: 1 },
       });
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xalready")
+      );
       const service = new SponsorWalletService();
 
       await expect(
@@ -217,6 +477,70 @@ describe("SponsorWalletService", () => {
       });
       expect(signTransaction).not.toHaveBeenCalled();
       expect(mockWeb3.eth.estimateGas).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith("0xraw");
+    });
+
+    it("keeps a durable signed row pending when broadcast fails", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const broadcastError = new Error("RPC unavailable");
+      const signTransaction = jest.fn(() =>
+        Promise.resolve({
+          rawTransaction: "0xdurable-raw",
+          transactionHash: "0xdurable-hash",
+        })
+      );
+      const committedTransaction = {
+        _id: "durable-id",
+        action: "submit-proofs",
+        walletId: "0xSponsor",
+        sourceTxHash: "durable-source",
+        status: "pending",
+        transaction: {
+          hash: "0xdurable-hash",
+          rawData: "0xdurable-raw",
+          nonce: 3,
+          confirmedHash: "",
+        },
+      };
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(3);
+      mockWeb3.eth.getTransaction.mockResolvedValue(undefined);
+      mockWeb3.eth.getGasPrice.mockResolvedValue("100");
+      mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        failedBroadcast(broadcastError)
+      );
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([]),
+      });
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue(
+        committedTransaction
+      );
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-durable",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "durable-source"
+        )
+      ).rejects.toThrow("RPC unavailable");
+
+      expect(SponsorWalletTransactionsMock.findOneAndUpdate).toHaveBeenCalled();
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith(
+        "0xdurable-raw"
+      );
+      expect(SponsorWalletTransactionsMock.updateOne).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: "failed" }),
+        })
+      );
     });
 
     it("rejects an unsigned sponsorship that is still in progress", async () => {
@@ -251,7 +575,8 @@ describe("SponsorWalletService", () => {
           transactionHash: "0xhash",
         })
       );
-      const stalePlaceholder = {
+      const stalePlaceholder: any = {
+        _id: "stale-id",
         transferId: "transfer-1",
         action: "submit-proofs",
         sourceTxHash: "deadbeef",
@@ -268,14 +593,26 @@ describe("SponsorWalletService", () => {
       mockWeb3.eth.getTransactionCount.mockResolvedValue(3);
       mockWeb3.eth.getGasPrice.mockResolvedValue("100");
       mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xhash")
+      );
       SponsorWalletTransactionsMock.findOne.mockResolvedValue(stalePlaceholder);
-      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue(
-        stalePlaceholder
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockImplementation(
+        (_query: any, update: any) => {
+          if (update.$set?.reservationOwner) {
+            stalePlaceholder.reservationOwner = update.$set.reservationOwner;
+            stalePlaceholder.reservationExpiresAt =
+              update.$set.reservationExpiresAt;
+            return Promise.resolve(stalePlaceholder);
+          }
+          return Promise.resolve({
+            ...stalePlaceholder,
+            transaction: update.$set.transaction,
+          });
+        }
       );
       SponsorWalletTransactionsMock.find.mockReturnValue({
-        sort: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        sort: () => Promise.resolve([]),
       });
       const service = new SponsorWalletService();
 
@@ -298,12 +635,14 @@ describe("SponsorWalletService", () => {
           action: "submit-proofs",
           status: "pending",
           "transaction.hash": { $exists: false },
-          updatedAt: { $lte: expect.any(Date) },
+          $and: expect.any(Array),
         }),
         expect.objectContaining({
           $set: expect.objectContaining({
             status: "pending",
             transaction: {},
+            reservationOwner: expect.any(String),
+            reservationExpiresAt: expect.any(Date),
             updatedAt: expect.any(Date),
           }),
         }),
@@ -323,9 +662,7 @@ describe("SponsorWalletService", () => {
       mockWeb3.eth.estimateGas.mockRejectedValue(new Error("execution reverted"));
       SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
       SponsorWalletTransactionsMock.find.mockReturnValue({
-        sort: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        sort: () => Promise.resolve([]),
       });
       const service = new SponsorWalletService();
 
@@ -345,6 +682,17 @@ describe("SponsorWalletService", () => {
   });
 
   describe("sponsorUtxoClaimGas", () => {
+    it("rejects legacy bridge transfers", async () => {
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorUtxoClaimGas({ ...transfer, version: "v1" })
+      ).rejects.toThrow(
+        "Foundation sponsorship is only available for V2 transfers"
+      );
+      expect(SponsorWalletTransactionsMock.findOne).not.toHaveBeenCalled();
+    });
+
     it("returns the existing claim gas transaction when one was already created", async () => {
       SponsorWalletTransactionsMock.findOne.mockResolvedValue({
         status: "pending",
@@ -444,6 +792,23 @@ describe("SponsorWalletService", () => {
       SponsorUtxoReservationMock.deleteOne.mockResolvedValue({
         deletedCount: 0,
       });
+      SponsorWalletTransactionsMock.findOneAndUpdate
+        .mockResolvedValueOnce({
+          _id: "placeholder-id",
+          reservationOwner: "utxo-owner",
+          status: "pending",
+          transaction: {},
+        })
+        .mockResolvedValueOnce({
+          _id: "placeholder-id",
+          status: "pending",
+          transaction: {
+            hash: "utxo-txid",
+            rawData: "utxo-txid",
+            nonce: 0,
+            confirmedHash: "",
+          },
+        });
       (global.fetch as jest.Mock<any>)
         .mockResolvedValueOnce({
           ok: true,
@@ -507,6 +872,46 @@ describe("SponsorWalletService", () => {
       expect(signAndSendWithWIF).toHaveBeenCalledWith(
         "unsigned-psbt",
         "sponsor-wif"
+      );
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate
+      ).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          _id: "placeholder-id",
+          status: "pending",
+          reservationOwner: expect.any(String),
+          reservationExpiresAt: { $gt: expect.any(Date) },
+          "transaction.hash": { $exists: false },
+        }),
+        expect.objectContaining({
+          $set: {
+            reservationExpiresAt: expect.any(Date),
+          },
+        }),
+        { new: true }
+      );
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate
+      ).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          _id: "placeholder-id",
+          status: "pending",
+          reservationOwner: "utxo-owner",
+          "transaction.hash": { $exists: false },
+        }),
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            status: "pending",
+            transaction: expect.objectContaining({ hash: "utxo-txid" }),
+          }),
+          $unset: {
+            reservationOwner: "",
+            reservationExpiresAt: "",
+          },
+        }),
+        { new: true }
       );
       expect(SponsorUtxoReservationMock.updateOne).toHaveBeenCalledWith(
         { key: "small-utxo:1" },
@@ -589,12 +994,14 @@ describe("SponsorWalletService", () => {
           "transaction.hash": { $exists: false },
           $or: [{ transferId: "transfer-1" }, { sourceTxHash: "0xburn" }],
         },
-        {
-          $set: {
+        expect.objectContaining({
+          $set: expect.objectContaining({
             status: "pending",
             transaction: {},
-          },
-        },
+            reservationOwner: expect.any(String),
+            reservationExpiresAt: expect.any(Date),
+          }),
+        }),
         { new: true }
       );
       expect(SponsorUtxoReservationMock.create).not.toHaveBeenCalled();
@@ -602,20 +1009,44 @@ describe("SponsorWalletService", () => {
 
     it("expires stale pending claim gas placeholders without a hash", async () => {
       const stalePlaceholder = {
+        _id: "stale-utxo-placeholder",
         status: "pending",
         transaction: {},
         updatedAt: new Date(Date.now() - 10 * 60_000),
-        save: jest.fn<any>().mockResolvedValue(undefined),
       };
       SponsorWalletTransactionsMock.findOne.mockResolvedValue(stalePlaceholder);
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue({
+        ...stalePlaceholder,
+        status: "failed",
+      });
 
       const service = new SponsorWalletService();
 
       await expect(
         service.getUtxoClaimGasSponsorStatus("transfer-1")
       ).resolves.toBeUndefined();
-      expect(stalePlaceholder.status).toBe("failed");
-      expect(stalePlaceholder.save).toHaveBeenCalled();
+      expect(SponsorWalletTransactionsMock.findOneAndUpdate).toHaveBeenCalledWith(
+        {
+          _id: "stale-utxo-placeholder",
+          status: "pending",
+          "transaction.hash": { $exists: false },
+          $or: [
+            { reservationExpiresAt: { $lte: expect.any(Date) } },
+            {
+              reservationExpiresAt: { $exists: false },
+              updatedAt: { $lte: expect.any(Date) },
+            },
+          ],
+        },
+        {
+          $set: { status: "failed" },
+          $unset: {
+            reservationOwner: "",
+            reservationExpiresAt: "",
+          },
+        },
+        { new: true }
+      );
     });
   });
 

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -333,6 +333,126 @@ describe("SponsorWalletService", () => {
       ).toBeLessThan(signTransaction.mock.invocationCallOrder[0]);
     });
 
+    it("fails closed when the chain advanced past an unknown durable transaction", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn();
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(8);
+      mockWeb3.eth.getTransaction.mockResolvedValue(undefined);
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () =>
+          Promise.resolve([
+            {
+              _id: "replaced-id",
+              action: "submit-proofs",
+              walletId: "0xSponsor",
+              sourceTxHash: "replaced-source",
+              status: "pending",
+              transaction: {
+                hash: "0xreplaced-hash",
+                rawData: "0xreplaced-raw",
+                nonce: 7,
+                confirmedHash: "",
+              },
+            },
+          ]),
+      });
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-after-replacement",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "new-source"
+        )
+      ).rejects.toThrow(
+        "Sponsor transaction 0xreplaced-hash was replaced at nonce 7"
+      );
+
+      expect(mockWeb3.eth.getTransaction).toHaveBeenCalledWith(
+        "0xreplaced-hash"
+      );
+      expect(signTransaction).not.toHaveBeenCalled();
+      expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
+    });
+
+    it("allows a known durable lower nonce before signing the chain nonce", async () => {
+      process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
+      const signTransaction = jest.fn(() =>
+        Promise.resolve({
+          rawTransaction: "0xnext-raw",
+          transactionHash: "0xnext-hash",
+        })
+      );
+      mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
+        address: "0xSponsor",
+        signTransaction,
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(8);
+      mockWeb3.eth.getTransaction.mockResolvedValue({
+        hash: "0xknown-hash",
+        nonce: 7,
+      });
+      mockWeb3.eth.getGasPrice.mockResolvedValue("100");
+      mockWeb3.eth.estimateGas.mockResolvedValue(120_000);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
+        successfulBroadcast("0xnext-hash")
+      );
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () =>
+          Promise.resolve([
+            {
+              _id: "known-id",
+              action: "submit-proofs",
+              walletId: "0xSponsor",
+              sourceTxHash: "known-source",
+              status: "pending",
+              transaction: {
+                hash: "0xknown-hash",
+                rawData: "0xknown-raw",
+                nonce: 7,
+                confirmedHash: "",
+              },
+            },
+          ]),
+      });
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValue({
+        _id: "next-id",
+        action: "submit-proofs",
+        walletId: "0xSponsor",
+        sourceTxHash: "new-source",
+        status: "pending",
+        transaction: {
+          hash: "0xnext-hash",
+          rawData: "0xnext-raw",
+          nonce: 8,
+          confirmedHash: "",
+        },
+      });
+      const service = new SponsorWalletService();
+
+      await service.sponsorTransaction(
+        "transfer-known-lower",
+        { to: "0xRelay", data: "0xdata", value: 0 },
+        "submit-proofs",
+        "new-source"
+      );
+
+      expect(signTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ nonce: 8 })
+      );
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledTimes(1);
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith(
+        "0xnext-raw"
+      );
+    });
+
     it("fails closed instead of signing across a durable nonce gap", async () => {
       process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
       const signTransaction = jest.fn();

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -1132,6 +1132,14 @@ describe("SponsorWalletService", () => {
         SponsorWalletTransactionsMock.findOneAndUpdate.mock
           .invocationCallOrder[0]
       ).toBeLessThan(signAndSendWithWIF.mock.invocationCallOrder[0]);
+      expect(SponsorUtxoReservationMock.updateOne).toHaveBeenNthCalledWith(
+        1,
+        { key: "small-utxo:1", status: "reserved" },
+        {
+          $set: { status: "broadcasting" },
+          $unset: { expiresAt: "" },
+        }
+      );
       expect(
         SponsorWalletTransactionsMock.findOneAndUpdate
       ).toHaveBeenNthCalledWith(
@@ -1174,16 +1182,17 @@ describe("SponsorWalletService", () => {
         }),
         { new: true }
       );
-      expect(SponsorUtxoReservationMock.updateOne).toHaveBeenCalledWith(
-        { key: "small-utxo:1" },
-        expect.objectContaining({
-          $set: expect.objectContaining({ status: "spent" }),
-        })
+      expect(SponsorUtxoReservationMock.updateOne).toHaveBeenNthCalledWith(
+        2,
+        { key: "small-utxo:1", status: "broadcasting" },
+        {
+          $set: {
+            status: "spent",
+            expiresAt: expect.any(Date),
+          },
+        }
       );
-      expect(SponsorUtxoReservationMock.deleteOne).toHaveBeenCalledWith({
-        key: "small-utxo:1",
-        status: "reserved",
-      });
+      expect(SponsorUtxoReservationMock.deleteOne).not.toHaveBeenCalled();
     });
 
     it("releases the reservation when UTXO construction fails before broadcast", async () => {
@@ -1249,6 +1258,70 @@ describe("SponsorWalletService", () => {
         key: "construction-utxo:0",
         status: "reserved",
       });
+    });
+
+    it("retains the specific UTXO when broadcast outcome is unknown", async () => {
+      process.env.UTXO_SPONSOR_ADDRESS = "sys1sponsor";
+      process.env.UTXO_SPONSOR_WIF = "sponsor-wif";
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      SponsorWalletTransactionsMock.findOneAndUpdate.mockResolvedValueOnce({
+        _id: "placeholder-id",
+        reservationOwner: "utxo-owner",
+        reservationPhase: "broadcasting",
+        status: "pending",
+        transaction: {},
+      });
+      SponsorUtxoReservationMock.create.mockResolvedValue({});
+      SponsorUtxoReservationMock.updateOne.mockResolvedValue({
+        modifiedCount: 1,
+      });
+      (global.fetch as jest.Mock<any>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ balance: "0" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ balance: "0" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              { txid: "ambiguous-utxo", vout: 0, value: "1000000" },
+            ]),
+        });
+      const createTransaction = jest.fn(() =>
+        Promise.resolve({ psbt: "unsigned-psbt" })
+      );
+      const signAndSendWithWIF = jest.fn(() =>
+        Promise.reject(new Error("Broadcast response lost"))
+      );
+      SyscoinMock.mockImplementation(() => ({
+        createTransaction,
+        signAndSendWithWIF,
+      }));
+
+      const service = new SponsorWalletService();
+
+      await expect(service.sponsorUtxoClaimGas(transfer)).rejects.toThrow(
+        "Broadcast response lost"
+      );
+
+      expect(SponsorUtxoReservationMock.updateOne).toHaveBeenCalledWith(
+        { key: "ambiguous-utxo:0", status: "reserved" },
+        {
+          $set: { status: "broadcasting" },
+          $unset: { expiresAt: "" },
+        }
+      );
+      expect(SponsorUtxoReservationMock.deleteOne).not.toHaveBeenCalled();
+      expect(SponsorWalletTransactionsMock.updateOne).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: "failed" }),
+        })
+      );
     });
 
     it("returns in-progress when a duplicate placeholder wins the race", async () => {

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -576,7 +576,7 @@ describe("SponsorWalletService", () => {
         action: "submit-proofs",
         sourceTxHash: "deadbeef",
         walletId: "0xSponsor",
-        status: "pending",
+        status: "success",
         transaction: { hash: "0xalready", rawData: "0xraw", nonce: 1 },
       });
       mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
@@ -593,11 +593,16 @@ describe("SponsorWalletService", () => {
         )
       ).resolves.toMatchObject({
         transferId: "transfer-alias-a",
+        status: "success",
         transaction: { hash: "0xalready" },
       });
       expect(signTransaction).not.toHaveBeenCalled();
       expect(mockWeb3.eth.estimateGas).not.toHaveBeenCalled();
       expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith("0xraw");
+      expect(SponsorWalletTransactionsMock.updateOne).toHaveBeenLastCalledWith(
+        { _id: "existing-id", "transaction.hash": "0xalready" },
+        { $set: { broadcastAt: expect.any(Date) } }
+      );
     });
 
     it("keeps a durable signed row pending when broadcast fails", async () => {
@@ -994,6 +999,10 @@ describe("SponsorWalletService", () => {
         "sponsor-wif"
       );
       expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate.mock
+          .invocationCallOrder[0]
+      ).toBeLessThan(signAndSendWithWIF.mock.invocationCallOrder[0]);
+      expect(
         SponsorWalletTransactionsMock.findOneAndUpdate
       ).toHaveBeenNthCalledWith(
         1,
@@ -1007,6 +1016,7 @@ describe("SponsorWalletService", () => {
         expect.objectContaining({
           $set: {
             reservationExpiresAt: expect.any(Date),
+            reservationPhase: "broadcasting",
           },
         }),
         { new: true }
@@ -1029,6 +1039,7 @@ describe("SponsorWalletService", () => {
           $unset: {
             reservationOwner: "",
             reservationExpiresAt: "",
+            reservationPhase: "",
           },
         }),
         { new: true }
@@ -1167,6 +1178,33 @@ describe("SponsorWalletService", () => {
         },
         { new: true }
       );
+    });
+
+    it("does not retry an expired UTXO reservation with an unknown broadcast outcome", async () => {
+      const broadcastingPlaceholder = {
+        _id: "broadcasting-utxo-placeholder",
+        status: "pending",
+        reservationPhase: "broadcasting",
+        reservationExpiresAt: new Date(Date.now() - 10 * 60_000),
+        transaction: {},
+      };
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(
+        broadcastingPlaceholder
+      );
+
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.getUtxoClaimGasSponsorStatus("transfer-1")
+      ).resolves.toEqual({
+        funded: true,
+        status: "pending",
+        reason:
+          "UTXO sponsorship broadcast outcome requires manual reconciliation",
+      });
+      expect(
+        SponsorWalletTransactionsMock.findOneAndUpdate
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -153,6 +153,7 @@ describe("SponsorWalletService", () => {
     delete process.env.UTXO_SPONSOR_ADDRESS;
     delete process.env.UTXO_SPONSOR_WIF;
     delete process.env.FOUNDATION_FUNDED;
+    process.env.NEVM_V2_ACTIVATION_BLOCK = "1";
     global.fetch = jest.fn() as any;
   });
 
@@ -933,14 +934,13 @@ describe("SponsorWalletService", () => {
   });
 
   describe("sponsorUtxoClaimGas", () => {
-    it("rejects legacy bridge transfers", async () => {
+    it("rejects claim gas for a pre-activation source block", async () => {
+      process.env.NEVM_V2_ACTIVATION_BLOCK = "100";
       const service = new SponsorWalletService();
 
       await expect(
-        service.sponsorUtxoClaimGas({ ...transfer, version: "v1" })
-      ).rejects.toThrow(
-        "Foundation sponsorship is only available for V2 transfers"
-      );
+        service.sponsorUtxoClaimGas(transfer, undefined, 99)
+      ).rejects.toThrow("before the V2 activation block");
       expect(SponsorWalletTransactionsMock.findOne).not.toHaveBeenCalled();
     });
 
@@ -952,7 +952,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).resolves.toEqual({
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).resolves.toEqual({
         funded: true,
         status: "pending",
         txid: "utxo-txid",
@@ -988,7 +990,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).resolves.toEqual({
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).resolves.toEqual({
         funded: false,
         status: "skipped",
         amountSats: 0,
@@ -1017,7 +1021,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).resolves.toEqual({
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).resolves.toEqual({
         funded: false,
         status: "skipped",
         amountSats: 0,
@@ -1095,7 +1101,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).resolves.toMatchObject(
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).resolves.toMatchObject(
         {
           funded: true,
           status: "pending",
@@ -1231,7 +1239,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).rejects.toThrow(
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).rejects.toThrow(
         "Unable to build PSBT"
       );
 
@@ -1304,7 +1314,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).rejects.toThrow(
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).rejects.toThrow(
         "Broadcast response lost"
       );
 
@@ -1347,7 +1359,9 @@ describe("SponsorWalletService", () => {
 
       const service = new SponsorWalletService();
 
-      await expect(service.sponsorUtxoClaimGas(transfer)).resolves.toEqual({
+      await expect(
+        service.sponsorUtxoClaimGas(transfer, undefined, 1)
+      ).resolves.toEqual({
         funded: true,
         status: "pending",
         reason: "UTXO claim gas sponsorship is already in progress",
@@ -1380,7 +1394,7 @@ describe("SponsorWalletService", () => {
       const service = new SponsorWalletService();
 
       await expect(
-        service.sponsorUtxoClaimGas(transfer, "0xburn")
+        service.sponsorUtxoClaimGas(transfer, "0xburn", 1)
       ).resolves.toEqual({
         funded: true,
         status: "pending",

--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -563,24 +563,43 @@ describe("SponsorWalletService", () => {
       expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
     });
 
-    it("returns an existing sponsorship for the same source tx under another transferId", async () => {
+    it("replays lower nonces before returning an existing sponsorship", async () => {
       process.env.NEVM_SPONSOR_PRIVATE_KEY = "nevm-private-key";
       const signTransaction = jest.fn();
       mockWeb3.eth.accounts.privateKeyToAccount.mockReturnValue({
         address: "0xSponsor",
         signTransaction,
       });
-      SponsorWalletTransactionsMock.findOne.mockResolvedValue({
+      const lowerTransaction = {
+        _id: "lower-id",
+        transferId: "transfer-lower",
+        action: "submit-proofs",
+        sourceTxHash: "lower-source",
+        walletId: "0xSponsor",
+        status: "pending",
+        transaction: { hash: "0xlower", rawData: "0xlower-raw", nonce: 1 },
+      };
+      const existingTransaction = {
         _id: "existing-id",
         transferId: "transfer-alias-a",
         action: "submit-proofs",
         sourceTxHash: "deadbeef",
         walletId: "0xSponsor",
-        status: "success",
-        transaction: { hash: "0xalready", rawData: "0xraw", nonce: 1 },
+        status: "pending",
+        transaction: { hash: "0xalready", rawData: "0xraw", nonce: 2 },
+      };
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(
+        existingTransaction
+      );
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([lowerTransaction, existingTransaction]),
       });
-      mockWeb3.eth.sendSignedTransaction.mockImplementation(() =>
-        successfulBroadcast("0xalready")
+      mockWeb3.eth.getTransactionCount
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(3);
+      mockWeb3.eth.sendSignedTransaction.mockImplementation((raw: string) =>
+        successfulBroadcast(raw === "0xlower-raw" ? "0xlower" : "0xalready")
       );
       const service = new SponsorWalletService();
 
@@ -593,15 +612,63 @@ describe("SponsorWalletService", () => {
         )
       ).resolves.toMatchObject({
         transferId: "transfer-alias-a",
-        status: "success",
+        status: "pending",
         transaction: { hash: "0xalready" },
       });
       expect(signTransaction).not.toHaveBeenCalled();
       expect(mockWeb3.eth.estimateGas).not.toHaveBeenCalled();
-      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenCalledWith("0xraw");
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenNthCalledWith(
+        1,
+        "0xlower-raw"
+      );
+      expect(mockWeb3.eth.sendSignedTransaction).toHaveBeenNthCalledWith(
+        2,
+        "0xraw"
+      );
       expect(SponsorWalletTransactionsMock.updateOne).toHaveBeenLastCalledWith(
         { _id: "existing-id", "transaction.hash": "0xalready" },
         { $set: { broadcastAt: expect.any(Date) } }
+      );
+    });
+
+    it("preserves a successful existing sponsorship without rebroadcasting it", async () => {
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue({
+        _id: "successful-id",
+        transferId: "transfer-successful",
+        action: "submit-proofs",
+        sourceTxHash: "successful-source",
+        walletId: "0xSponsor",
+        status: "success",
+        transaction: {
+          hash: "0xsuccessful",
+          rawData: "0xsuccessful-raw",
+          nonce: 1,
+        },
+      });
+      SponsorWalletTransactionsMock.find.mockReturnValue({
+        sort: () => Promise.resolve([]),
+      });
+      mockWeb3.eth.getTransactionCount.mockResolvedValue(2);
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.sponsorTransaction(
+          "transfer-successful",
+          { to: "0xRelay", data: "0xdata", value: 0 },
+          "submit-proofs",
+          "successful-source"
+        )
+      ).resolves.toMatchObject({
+        status: "success",
+        transaction: { hash: "0xsuccessful" },
+      });
+
+      expect(mockWeb3.eth.sendSignedTransaction).not.toHaveBeenCalled();
+      expect(SponsorWalletTransactionsMock.updateOne).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: "pending" }),
+        })
       );
     });
 

--- a/api/services/__tests__/transfer.test.ts
+++ b/api/services/__tests__/transfer.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const TransferModelMock = {
+  create: jest.fn<any>(),
+  findOne: jest.fn<any>(),
+  findOneAndUpdate: jest.fn<any>(),
+};
+
+jest.mock("models/transfer", () => ({
+  __esModule: true,
+  default: TransferModelMock,
+}));
+jest.mock("../sponsor-wallet", () => ({
+  SponsorWalletService: jest.fn().mockImplementation(() => ({
+    updateSponsorWalletTransactionStatus: jest.fn(),
+    updateUtxoSponsorWalletTransactionStatus: jest.fn(),
+  })),
+}));
+
+import { createHash } from "crypto";
+import {
+  ETH_TO_SYS_TRANSFER_STATUS,
+  ITransfer,
+} from "@contexts/Transfer/types";
+import {
+  TransferService,
+  TransferWriteUnauthorizedError,
+} from "../transfer";
+
+const transfer: ITransfer = {
+  id: "transfer-id",
+  type: "nevm-to-sys",
+  status: ETH_TO_SYS_TRANSFER_STATUS.FREEZE_BURN_SYS,
+  amount: "1",
+  logs: [],
+  createdAt: 1,
+  utxoAddress: "sys1destination",
+  nevmAddress: "0x1111111111111111111111111111111111111111",
+  version: "v2",
+  agreedToTerms: true,
+};
+
+const findExisting = (value: unknown) => {
+  TransferModelMock.findOne.mockReturnValue({
+    select: jest.fn<any>().mockResolvedValue(value),
+  });
+};
+
+describe("TransferService write capabilities", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects updates to an existing transfer without its write token", async () => {
+    findExisting({ ...transfer, writeTokenHash: "00".repeat(32) });
+
+    await expect(
+      new TransferService().upsertTransfer(transfer)
+    ).rejects.toBeInstanceOf(TransferWriteUnauthorizedError);
+    expect(TransferModelMock.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates only the URL-bound transfer when the capability matches", async () => {
+    const writeToken = "secret-capability";
+    const writeTokenHash = createHash("sha256")
+      .update(writeToken)
+      .digest("hex");
+    findExisting({ ...transfer, writeTokenHash });
+    TransferModelMock.findOneAndUpdate.mockResolvedValue(transfer);
+
+    await expect(
+      new TransferService().upsertTransfer(transfer, writeToken)
+    ).resolves.toEqual({ transfer });
+    expect(TransferModelMock.findOneAndUpdate).toHaveBeenCalledWith(
+      { id: transfer.id, writeTokenHash },
+      expect.objectContaining({
+        $set: expect.not.objectContaining({
+          id: expect.anything(),
+          version: expect.anything(),
+          writeTokenHash: expect.anything(),
+        }),
+      }),
+      { new: true }
+    );
+  });
+
+  it("binds a new record to the supplied capability and forces V2", async () => {
+    findExisting(null);
+    TransferModelMock.create.mockImplementation(async (value: any) => value);
+
+    const result = await new TransferService().upsertTransfer({
+      ...transfer,
+      version: "v1",
+    }, "new-transfer-capability");
+
+    expect(result.transfer.version).toBe("v2");
+    expect(result.transfer).not.toHaveProperty("writeTokenHash");
+    expect(TransferModelMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: transfer.id,
+        version: "v2",
+        writeTokenHash: expect.any(String),
+      })
+    );
+  });
+
+  it("does not create a transfer without a capability", async () => {
+    findExisting(null);
+
+    await expect(
+      new TransferService().upsertTransfer(transfer)
+    ).rejects.toBeInstanceOf(TransferWriteUnauthorizedError);
+    expect(TransferModelMock.create).not.toHaveBeenCalled();
+  });
+});

--- a/api/services/sponsor-eligibility.ts
+++ b/api/services/sponsor-eligibility.ts
@@ -1,0 +1,48 @@
+const parseBlockNumber = (value: unknown, label: string): bigint => {
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+  ) {
+    return BigInt(value);
+  }
+
+  if (
+    typeof value === "string" &&
+    (/^\d+$/.test(value) || /^0x[0-9a-f]+$/i.test(value))
+  ) {
+    return BigInt(value);
+  }
+
+  if (typeof value === "bigint" && value >= BigInt(0)) {
+    return value;
+  }
+
+  throw new Error(`${label} is not a valid block number`);
+};
+
+export const getV2ActivationBlock = (): bigint => {
+  const configuredActivationBlock = process.env.NEVM_V2_ACTIVATION_BLOCK;
+  if (!configuredActivationBlock) {
+    throw new Error("NEVM V2 activation block is not configured");
+  }
+
+  return parseBlockNumber(
+    configuredActivationBlock,
+    "NEVM V2 activation block"
+  );
+};
+
+export const assertV2ActivationBlock = (receiptBlockNumber: unknown): void => {
+  const activationBlock = getV2ActivationBlock();
+  const eventBlock = parseBlockNumber(
+    receiptBlockNumber,
+    "Freeze and burn receipt block"
+  );
+
+  if (eventBlock < activationBlock) {
+    throw new Error(
+      "Freeze and burn transaction is before the V2 activation block"
+    );
+  }
+};

--- a/api/services/sponsor-proof.ts
+++ b/api/services/sponsor-proof.ts
@@ -1,0 +1,49 @@
+import { SPVProof, utils as syscoinUtils } from "syscoinjs-lib";
+import {
+  MAINNET_BLOCKBOOK_URL,
+  resolveUtxoBlockbookUrl,
+} from "utils/syscoin-urls";
+import { syscoinTxIdFromWitnessStrippedHex } from "utils/syscoin-txid";
+
+const getUtxoBlockbookUrl = () =>
+  resolveUtxoBlockbookUrl(process.env.UTXO_RPC_URL) ??
+  resolveUtxoBlockbookUrl(process.env.UTXO_EXPLORER) ??
+  MAINNET_BLOCKBOOK_URL;
+
+const parseProof = (value: unknown): SPVProof => {
+  const proof = typeof value === "string" ? JSON.parse(value) : value;
+  if (
+    !proof ||
+    typeof proof !== "object" ||
+    !("transaction" in proof) ||
+    typeof proof.transaction !== "string"
+  ) {
+    throw new Error("Canonical SPV proof is unavailable");
+  }
+  return proof as SPVProof;
+};
+
+export const getCanonicalChainLockedProof = async (
+  submittedProof: SPVProof
+): Promise<{ proof: SPVProof; sourceTxHash: string }> => {
+  const sourceTxHash = syscoinTxIdFromWitnessStrippedHex(
+    submittedProof.transaction
+  );
+  const response = await syscoinUtils.fetchBackendSPVProof(
+    getUtxoBlockbookUrl(),
+    sourceTxHash
+  );
+  const proof = parseProof(response?.result);
+  const canonicalSourceTxHash = syscoinTxIdFromWitnessStrippedHex(
+    proof.transaction
+  );
+
+  if (canonicalSourceTxHash !== sourceTxHash) {
+    throw new Error("Canonical SPV proof does not match the source transaction");
+  }
+  if (proof.chainlock !== true) {
+    throw new Error("Source transaction is not ChainLocked");
+  }
+
+  return { proof, sourceTxHash };
+};

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -1,5 +1,5 @@
 import { ITransfer } from "@contexts/Transfer/types";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import SponsorUtxoReservation from "models/sponsor-utxo-reservation";
 import SponsorWalletTransactions, {
   ISponsorWalletTransaction,
@@ -31,11 +31,19 @@ const DEFAULT_UTXO_CLAIM_GAS_AMOUNT_SYS = "0.001";
 const DEFAULT_UTXO_FEE_RATE = 10;
 const UTXO_CLAIM_GAS_FEE_BUFFER_SATS = DEFAULT_UTXO_FEE_RATE * 250;
 const SPONSOR_RESERVATION_LEASE_MS = 5 * 60_000;
+const SPONSOR_PROTOCOL_VERSION = 2;
 
 export class SponsorshipInProgressError extends Error {
   constructor() {
     super("Sponsorship is already in progress");
     this.name = "SponsorshipInProgressError";
+  }
+}
+
+export class SponsorNonceRecoveryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SponsorNonceRecoveryError";
   }
 }
 
@@ -90,17 +98,6 @@ const isDuplicateKeyError = (error: unknown) => {
   );
 };
 
-const getDocumentUpdatedAtMs = (document: unknown) => {
-  const updatedAt = (document as { updatedAt?: Date | string | number })
-    .updatedAt;
-
-  if (!updatedAt) {
-    return undefined;
-  }
-
-  return new Date(updatedAt).getTime();
-};
-
 export class SponsorWalletService {
   public async sponsorTransaction(
     transferId: string,
@@ -130,6 +127,15 @@ export class SponsorWalletService {
     );
 
     if (existingTransaction?.transaction?.hash) {
+      if (
+        action === SUBMIT_PROOFS_ACTION &&
+        existingTransaction.sourceTxHash?.toLowerCase() !== normalizedSource
+      ) {
+        throw new SponsorNonceRecoveryError(
+          "Legacy or mismatched signed sponsorship cannot be reused in V2"
+        );
+      }
+      await this.broadcastSponsorTransaction(existingTransaction);
       return existingTransaction;
     }
 
@@ -154,6 +160,7 @@ export class SponsorWalletService {
     }
 
     const sender = web3.eth.accounts.privateKeyToAccount(privateKey);
+    await this.assertNoUnsafeLegacySponsorTransactions(sender.address);
 
     // Reserve (transferId, action) and (action, sourceTxHash) before nonce /
     // estimate / sign so concurrent aliases of the same burn cannot each mint
@@ -210,8 +217,9 @@ export class SponsorWalletService {
       }
     }
 
+    let committedTransaction: ISponsorWalletTransaction | null = null;
     try {
-      const nonce = await this.getAddressNextNonce(sender.address);
+      const nonce = await this.recoverSponsorNonceQueue(sender.address);
       const gasPrice = await web3.eth.getGasPrice();
       let gas: number;
       try {
@@ -241,21 +249,22 @@ export class SponsorWalletService {
         throw new Error("Raw transaction is undefined");
       }
 
-      placeholder.transaction = {
-        hash: signedTransaction.transactionHash,
-        rawData: signedTransaction.rawTransaction,
-        nonce,
-        confirmedHash: "",
-      };
-      placeholder.status = "pending";
-      if (normalizedSource) {
-        placeholder.sourceTxHash = normalizedSource;
-      }
-      await placeholder.save();
-      return placeholder;
+      committedTransaction = await this.commitSignedSponsorTransaction(
+        placeholder,
+        normalizedSource,
+        signedTransaction.transactionHash,
+        signedTransaction.rawTransaction,
+        nonce
+      );
+      await this.broadcastSponsorTransaction(committedTransaction);
+      return committedTransaction;
     } catch (error) {
-      placeholder.status = "failed";
-      await placeholder.save().catch(() => undefined);
+      if (!committedTransaction) {
+        await this.failSponsorReservation(placeholder);
+      }
+      if (isDuplicateKeyError(error)) {
+        throw new SponsorshipInProgressError();
+      }
       throw error;
     }
   }
@@ -264,6 +273,10 @@ export class SponsorWalletService {
     transfer: ITransfer,
     sourceTxHash?: string
   ): Promise<SponsorClaimGasResult> {
+    if (transfer.version !== "v2") {
+      throw new Error("Foundation sponsorship is only available for V2 transfers");
+    }
+
     if (transfer.type !== "nevm-to-sys") {
       throw new Error("UTXO claim gas sponsorship is only for NEVM to SYS");
     }
@@ -331,12 +344,14 @@ export class SponsorWalletService {
     }
 
     let reservation: { key: string; utxo: SponsorUtxo } | undefined;
+    let transactionSent = false;
     try {
       reservation = await this.reserveSponsorUtxo(
         sponsorAddress,
         transfer.id,
         targetAmountSats + UTXO_CLAIM_GAS_FEE_BUFFER_SATS
       );
+      placeholder = await this.renewSponsorReservation(placeholder);
       const txid = await this.sendUtxoClaimGas(
         sponsorAddress,
         sponsorWif,
@@ -344,15 +359,9 @@ export class SponsorWalletService {
         targetAmountSats,
         reservation.utxo
       );
+      transactionSent = true;
 
-      placeholder.transaction = {
-        hash: txid,
-        rawData: txid,
-        nonce: 0,
-        confirmedHash: "",
-      };
-      placeholder.status = "pending";
-      await placeholder.save();
+      await this.commitUtxoSponsorTransaction(placeholder, txid);
       await this.markSponsorUtxoSpent(reservation.key);
 
       return {
@@ -362,8 +371,9 @@ export class SponsorWalletService {
         amountSats: targetAmountSats,
       };
     } catch (error) {
-      placeholder.status = "failed";
-      await placeholder.save();
+      if (!transactionSent) {
+        await this.failSponsorReservation(placeholder);
+      }
       throw error;
     } finally {
       if (reservation) {
@@ -393,13 +403,31 @@ export class SponsorWalletService {
     }
 
     if (existingTransaction?.status === "pending") {
-      const updatedAtMs = getDocumentUpdatedAtMs(existingTransaction);
-      if (
-        updatedAtMs !== undefined &&
-        Date.now() - updatedAtMs > SPONSOR_RESERVATION_LEASE_MS
-      ) {
-        existingTransaction.status = "failed";
-        await existingTransaction.save();
+      const now = new Date();
+      const leaseCutoff = new Date(Date.now() - SPONSOR_RESERVATION_LEASE_MS);
+      const expired = await SponsorWalletTransactions.findOneAndUpdate(
+        {
+          _id: existingTransaction._id,
+          status: "pending",
+          "transaction.hash": { $exists: false },
+          $or: [
+            { reservationExpiresAt: { $lte: now } },
+            {
+              reservationExpiresAt: { $exists: false },
+              updatedAt: { $lte: leaseCutoff },
+            },
+          ],
+        },
+        {
+          $set: { status: "failed" },
+          $unset: {
+            reservationOwner: "",
+            reservationExpiresAt: "",
+          },
+        },
+        { new: true }
+      );
+      if (expired) {
         return undefined;
       }
 
@@ -511,13 +539,19 @@ export class SponsorWalletService {
     walletId: string,
     sourceTxHash?: string
   ): Promise<SponsorPlaceholderResult> {
+    const reservationOwner = randomUUID();
     const placeholder = new SponsorWalletTransactions({
       transferId,
       action,
       sourceTxHash,
+      sponsorProtocolVersion: SPONSOR_PROTOCOL_VERSION,
       walletId,
       status: "pending",
       transaction: {},
+      reservationOwner,
+      reservationExpiresAt: new Date(
+        Date.now() + SPONSOR_RESERVATION_LEASE_MS
+      ),
     });
 
     return placeholder
@@ -548,6 +582,7 @@ export class SponsorWalletService {
     action: SponsorWalletTransactionAction,
     sourceTxHash?: string
   ): Promise<ISponsorWalletTransaction | null> {
+    const reservationOwner = randomUUID();
     return SponsorWalletTransactions.findOneAndUpdate(
       {
         action,
@@ -562,6 +597,11 @@ export class SponsorWalletService {
         $set: {
           status: "pending",
           transaction: {},
+          sponsorProtocolVersion: SPONSOR_PROTOCOL_VERSION,
+          reservationOwner,
+          reservationExpiresAt: new Date(
+            Date.now() + SPONSOR_RESERVATION_LEASE_MS
+          ),
         },
       },
       { new: true }
@@ -573,30 +613,341 @@ export class SponsorWalletService {
     action: SponsorWalletTransactionAction,
     sourceTxHash?: string
   ): Promise<ISponsorWalletTransaction | null> {
-    const leaseCutoff = new Date(
-      Date.now() - SPONSOR_RESERVATION_LEASE_MS
-    );
+    const now = new Date();
+    const leaseCutoff = new Date(Date.now() - SPONSOR_RESERVATION_LEASE_MS);
+    const reservationOwner = randomUUID();
 
     return SponsorWalletTransactions.findOneAndUpdate(
       {
         action,
         status: "pending",
         "transaction.hash": { $exists: false },
-        updatedAt: { $lte: leaseCutoff },
-        $or: [
-          { transferId },
-          ...(sourceTxHash ? [{ sourceTxHash }] : []),
+        $and: [
+          {
+            $or: [
+              { transferId },
+              ...(sourceTxHash ? [{ sourceTxHash }] : []),
+            ],
+          },
+          {
+            $or: [
+              { reservationExpiresAt: { $lte: now } },
+              {
+                reservationExpiresAt: { $exists: false },
+                updatedAt: { $lte: leaseCutoff },
+              },
+            ],
+          },
         ],
       },
       {
         $set: {
           status: "pending",
           transaction: {},
-          updatedAt: new Date(),
+          sponsorProtocolVersion: SPONSOR_PROTOCOL_VERSION,
+          reservationOwner,
+          reservationExpiresAt: new Date(
+            Date.now() + SPONSOR_RESERVATION_LEASE_MS
+          ),
+          updatedAt: now,
         },
       },
       { new: true }
     );
+  }
+
+  private async assertNoUnsafeLegacySponsorTransactions(walletId: string) {
+    const unsafeRows = await SponsorWalletTransactions.countDocuments({
+      walletId,
+      "transaction.rawData": { $type: "string" },
+      "transaction.nonce": { $type: "number" },
+      $or: [
+        { action: { $exists: false } },
+        {
+          action: SUBMIT_PROOFS_ACTION,
+          sourceTxHash: { $exists: false },
+        },
+        {
+          action: SUBMIT_PROOFS_ACTION,
+          sourceTxHash: null,
+        },
+      ],
+    });
+
+    if (unsafeRows > 0) {
+      throw new SponsorNonceRecoveryError(
+        "Foundation funding blocked: reconcile legacy signed sponsor rows before V2 sponsorship"
+      );
+    }
+  }
+
+  private async commitSignedSponsorTransaction(
+    placeholder: ISponsorWalletTransaction,
+    sourceTxHash: string | undefined,
+    transactionHash: string,
+    rawTransaction: string,
+    nonce: number
+  ): Promise<ISponsorWalletTransaction> {
+    if (!placeholder.reservationOwner) {
+      throw new SponsorshipInProgressError();
+    }
+
+    const committed = await SponsorWalletTransactions.findOneAndUpdate(
+      {
+        _id: placeholder._id,
+        status: "pending",
+        reservationOwner: placeholder.reservationOwner,
+        reservationExpiresAt: { $gt: new Date() },
+        "transaction.hash": { $exists: false },
+      },
+      {
+        $set: {
+          sourceTxHash,
+          sponsorProtocolVersion: SPONSOR_PROTOCOL_VERSION,
+          status: "pending",
+          transaction: {
+            hash: transactionHash,
+            rawData: rawTransaction,
+            nonce,
+            confirmedHash: "",
+          },
+        },
+        $unset: {
+          reservationOwner: "",
+          reservationExpiresAt: "",
+        },
+      },
+      { new: true }
+    );
+
+    if (!committed) {
+      throw new SponsorshipInProgressError();
+    }
+
+    return committed;
+  }
+
+  private async renewSponsorReservation(
+    placeholder: ISponsorWalletTransaction
+  ): Promise<ISponsorWalletTransaction> {
+    if (!placeholder.reservationOwner) {
+      throw new SponsorshipInProgressError();
+    }
+
+    const renewed = await SponsorWalletTransactions.findOneAndUpdate(
+      {
+        _id: placeholder._id,
+        status: "pending",
+        reservationOwner: placeholder.reservationOwner,
+        reservationExpiresAt: { $gt: new Date() },
+        "transaction.hash": { $exists: false },
+      },
+      {
+        $set: {
+          reservationExpiresAt: new Date(
+            Date.now() + SPONSOR_RESERVATION_LEASE_MS
+          ),
+        },
+      },
+      { new: true }
+    );
+
+    if (!renewed) {
+      throw new SponsorshipInProgressError();
+    }
+
+    return renewed;
+  }
+
+  private async commitUtxoSponsorTransaction(
+    placeholder: ISponsorWalletTransaction,
+    transactionHash: string
+  ): Promise<ISponsorWalletTransaction> {
+    if (!placeholder.reservationOwner) {
+      throw new SponsorshipInProgressError();
+    }
+
+    const committed = await SponsorWalletTransactions.findOneAndUpdate(
+      {
+        _id: placeholder._id,
+        status: "pending",
+        reservationOwner: placeholder.reservationOwner,
+        "transaction.hash": { $exists: false },
+      },
+      {
+        $set: {
+          status: "pending",
+          transaction: {
+            hash: transactionHash,
+            rawData: transactionHash,
+            nonce: 0,
+            confirmedHash: "",
+          },
+        },
+        $unset: {
+          reservationOwner: "",
+          reservationExpiresAt: "",
+        },
+      },
+      { new: true }
+    );
+
+    if (!committed) {
+      throw new SponsorshipInProgressError();
+    }
+
+    return committed;
+  }
+
+  private async failSponsorReservation(
+    placeholder: ISponsorWalletTransaction
+  ): Promise<void> {
+    if (!placeholder.reservationOwner) {
+      return;
+    }
+
+    await SponsorWalletTransactions.updateOne(
+      {
+        _id: placeholder._id,
+        reservationOwner: placeholder.reservationOwner,
+        "transaction.hash": { $exists: false },
+      },
+      {
+        $set: { status: "failed" },
+        $unset: {
+          reservationOwner: "",
+          reservationExpiresAt: "",
+        },
+      }
+    ).catch(() => undefined);
+  }
+
+  private async recoverSponsorNonceQueue(walletId: string): Promise<number> {
+    let pendingNonce = await web3.eth.getTransactionCount(walletId, "pending");
+    const pendingTransactions = await SponsorWalletTransactions.find({
+      action: SUBMIT_PROOFS_ACTION,
+      walletId,
+      status: { $in: ["pending", "failed"] },
+      sourceTxHash: { $type: "string" },
+      "transaction.rawData": { $type: "string" },
+      "transaction.nonce": { $gte: pendingNonce },
+    }).sort({ "transaction.nonce": 1 });
+
+    for (const pendingTransaction of pendingTransactions) {
+      const storedNonce = pendingTransaction.transaction.nonce;
+      if (storedNonce < pendingNonce) {
+        continue;
+      }
+      if (storedNonce > pendingNonce) {
+        throw new SponsorNonceRecoveryError(
+          `Sponsor nonce recovery blocked: missing durable transaction for nonce ${pendingNonce}`
+        );
+      }
+
+      await this.broadcastSponsorTransaction(pendingTransaction);
+      const refreshedNonce = await web3.eth.getTransactionCount(
+        walletId,
+        "pending"
+      );
+      if (refreshedNonce <= storedNonce) {
+        throw new SponsorshipInProgressError();
+      }
+      pendingNonce = refreshedNonce;
+    }
+
+    return pendingNonce;
+  }
+
+  private async broadcastSponsorTransaction(
+    sponsorTransaction: ISponsorWalletTransaction
+  ): Promise<void> {
+    const { hash, rawData, nonce } = sponsorTransaction.transaction ?? {};
+    if (
+      !hash ||
+      !rawData ||
+      typeof nonce !== "number" ||
+      !sponsorTransaction.walletId
+    ) {
+      throw new SponsorNonceRecoveryError(
+        "Signed sponsor transaction is incomplete and cannot be broadcast"
+      );
+    }
+
+    await SponsorWalletTransactions.updateOne(
+      { _id: sponsorTransaction._id, "transaction.hash": hash },
+      { $inc: { broadcastAttempts: 1 } }
+    );
+
+    try {
+      await this.sendRawSponsorTransaction(rawData, hash);
+    } catch (error) {
+      const [knownTransaction, pendingNonce] = await Promise.all([
+        web3.eth.getTransaction(hash).catch(() => undefined),
+        web3.eth
+          .getTransactionCount(sponsorTransaction.walletId, "pending")
+          .catch(() => undefined),
+      ]);
+      if (knownTransaction) {
+        // Re-broadcasts are idempotent; an "already known" RPC error is safe.
+      } else if (pendingNonce !== undefined && pendingNonce > nonce) {
+        throw new SponsorNonceRecoveryError(
+          `Sponsor transaction ${hash} was replaced at nonce ${nonce}; manual reconciliation is required`
+        );
+      } else {
+        throw error;
+      }
+    }
+
+    await SponsorWalletTransactions.updateOne(
+      { _id: sponsorTransaction._id, "transaction.hash": hash },
+      { $set: { broadcastAt: new Date(), status: "pending" } }
+    );
+  }
+
+  private async sendRawSponsorTransaction(
+    rawTransaction: string,
+    expectedHash: string
+  ): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (callback: () => void) => {
+        if (!settled) {
+          settled = true;
+          callback();
+        }
+      };
+
+      try {
+        const promiEvent = web3.eth.sendSignedTransaction(rawTransaction);
+        promiEvent
+          .once("transactionHash", (value: string | { hash?: string }) => {
+            const hash = typeof value === "string" ? value : value?.hash;
+            if (!hash || hash.toLowerCase() !== expectedHash.toLowerCase()) {
+              finish(() =>
+                reject(
+                  new Error(
+                    "Sponsor RPC returned an unexpected transaction hash"
+                  )
+                )
+              );
+              return;
+            }
+            finish(resolve);
+          })
+          .on("error", (error: Error) => finish(() => reject(error)));
+        void promiEvent.catch((error: Error) =>
+          finish(() => reject(error))
+        );
+      } catch (error) {
+        finish(() =>
+          reject(
+            error instanceof Error
+              ? error
+              : new Error("Unable to broadcast sponsor transaction")
+          )
+        );
+      }
+    });
   }
 
   private async getUtxoAddressBalanceSats(address: string): Promise<number> {
@@ -747,24 +1098,6 @@ export class SponsorWalletService {
     return [...utxos].sort((a, b) => Number(a.value) - Number(b.value));
   }
 
-  private async getAddressNextNonce(address: string): Promise<number> {
-    // Ignore reservation placeholders (transaction: {}) so an empty nonce field
-    // cannot collapse internalNonce to undefined/NaN.
-    const [lastTransaction] = await SponsorWalletTransactions.find({
-      walletId: address,
-      "transaction.nonce": { $type: "number" },
-    })
-      .sort({ "transaction.nonce": -1 })
-      .limit(1);
-
-    const pendingNonce = await web3.eth.getTransactionCount(address, "pending");
-
-    const internalNonce = lastTransaction
-      ? lastTransaction.transaction.nonce
-      : -1;
-
-    return pendingNonce > internalNonce ? pendingNonce : internalNonce + 1;
-  }
 }
 
 export default SponsorWalletService;

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -865,7 +865,6 @@ export class SponsorWalletService {
     const pendingTransactions = await SponsorWalletTransactions.find({
       action: SUBMIT_PROOFS_ACTION,
       walletId,
-      status: { $in: ["pending", "failed"] },
       sourceTxHash: { $type: "string" },
       "transaction.rawData": { $type: "string" },
       "transaction.nonce": { $type: "number" },

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -344,14 +344,15 @@ export class SponsorWalletService {
     }
 
     let reservation: { key: string; utxo: SponsorUtxo } | undefined;
-    let transactionSent = false;
+    let broadcastStarted = false;
     try {
       reservation = await this.reserveSponsorUtxo(
         sponsorAddress,
         transfer.id,
         targetAmountSats + UTXO_CLAIM_GAS_FEE_BUFFER_SATS
       );
-      placeholder = await this.renewSponsorReservation(placeholder);
+      placeholder = await this.beginUtxoSponsorBroadcast(placeholder);
+      broadcastStarted = true;
       const txid = await this.sendUtxoClaimGas(
         sponsorAddress,
         sponsorWif,
@@ -359,7 +360,6 @@ export class SponsorWalletService {
         targetAmountSats,
         reservation.utxo
       );
-      transactionSent = true;
 
       await this.commitUtxoSponsorTransaction(placeholder, txid);
       await this.markSponsorUtxoSpent(reservation.key);
@@ -371,7 +371,7 @@ export class SponsorWalletService {
         amountSats: targetAmountSats,
       };
     } catch (error) {
-      if (!transactionSent) {
+      if (!broadcastStarted) {
         await this.failSponsorReservation(placeholder);
       }
       throw error;
@@ -403,6 +403,15 @@ export class SponsorWalletService {
     }
 
     if (existingTransaction?.status === "pending") {
+      if (existingTransaction.reservationPhase === "broadcasting") {
+        return {
+          funded: true,
+          status: "pending",
+          reason:
+            "UTXO sponsorship broadcast outcome requires manual reconciliation",
+        };
+      }
+
       const now = new Date();
       const leaseCutoff = new Date(Date.now() - SPONSOR_RESERVATION_LEASE_MS);
       const expired = await SponsorWalletTransactions.findOneAndUpdate(
@@ -552,6 +561,7 @@ export class SponsorWalletService {
       reservationExpiresAt: new Date(
         Date.now() + SPONSOR_RESERVATION_LEASE_MS
       ),
+      reservationPhase: "reserved",
     });
 
     return placeholder
@@ -602,6 +612,7 @@ export class SponsorWalletService {
           reservationExpiresAt: new Date(
             Date.now() + SPONSOR_RESERVATION_LEASE_MS
           ),
+          reservationPhase: "reserved",
         },
       },
       { new: true }
@@ -649,6 +660,7 @@ export class SponsorWalletService {
           reservationExpiresAt: new Date(
             Date.now() + SPONSOR_RESERVATION_LEASE_MS
           ),
+          reservationPhase: "reserved",
           updatedAt: now,
         },
       },
@@ -715,6 +727,7 @@ export class SponsorWalletService {
         $unset: {
           reservationOwner: "",
           reservationExpiresAt: "",
+          reservationPhase: "",
         },
       },
       { new: true }
@@ -727,7 +740,7 @@ export class SponsorWalletService {
     return committed;
   }
 
-  private async renewSponsorReservation(
+  private async beginUtxoSponsorBroadcast(
     placeholder: ISponsorWalletTransaction
   ): Promise<ISponsorWalletTransaction> {
     if (!placeholder.reservationOwner) {
@@ -747,6 +760,7 @@ export class SponsorWalletService {
           reservationExpiresAt: new Date(
             Date.now() + SPONSOR_RESERVATION_LEASE_MS
           ),
+          reservationPhase: "broadcasting",
         },
       },
       { new: true }
@@ -787,6 +801,7 @@ export class SponsorWalletService {
         $unset: {
           reservationOwner: "",
           reservationExpiresAt: "",
+          reservationPhase: "",
         },
       },
       { new: true }
@@ -817,6 +832,7 @@ export class SponsorWalletService {
         $unset: {
           reservationOwner: "",
           reservationExpiresAt: "",
+          reservationPhase: "",
         },
       }
     ).catch(() => undefined);
@@ -908,7 +924,7 @@ export class SponsorWalletService {
 
     await SponsorWalletTransactions.updateOne(
       { _id: sponsorTransaction._id, "transaction.hash": hash },
-      { $set: { broadcastAt: new Date(), status: "pending" } }
+      { $set: { broadcastAt: new Date() } }
     );
   }
 

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -1,5 +1,5 @@
 import { ITransfer } from "@contexts/Transfer/types";
-import { createHash, randomUUID } from "crypto";
+import { randomUUID } from "crypto";
 import SponsorUtxoReservation from "models/sponsor-utxo-reservation";
 import SponsorWalletTransactions, {
   ISponsorWalletTransaction,
@@ -13,17 +13,8 @@ import {
   resolveUtxoBlockbookUrl,
 } from "utils/syscoin-urls";
 import { TransactionConfig } from "web3-core";
-
-/** Bitcoin/Syscoin txid (display hex) from witness-stripped serialization. */
-export function syscoinTxIdFromWitnessStrippedHex(txHex: string): string {
-  const hex = txHex.startsWith("0x") ? txHex.slice(2) : txHex;
-  if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
-    throw new Error("Invalid witness-stripped transaction hex");
-  }
-  const firstHash = createHash("sha256").update(hex, "hex").digest("hex");
-  const hash = createHash("sha256").update(firstHash, "hex").digest("hex");
-  return hash.match(/.{2}/g)!.reverse().join("");
-}
+import { assertV2ActivationBlock } from "./sponsor-eligibility";
+export { syscoinTxIdFromWitnessStrippedHex } from "utils/syscoin-txid";
 
 const SUBMIT_PROOFS_ACTION: SponsorWalletTransactionAction = "submit-proofs";
 const UTXO_CLAIM_GAS_ACTION: SponsorWalletTransactionAction = "utxo-claim-gas";
@@ -277,11 +268,10 @@ export class SponsorWalletService {
 
   public async sponsorUtxoClaimGas(
     transfer: ITransfer,
-    sourceTxHash?: string
+    sourceTxHash: string | undefined,
+    sourceBlockNumber: number | string | bigint
   ): Promise<SponsorClaimGasResult> {
-    if (transfer.version !== "v2") {
-      throw new Error("Foundation sponsorship is only available for V2 transfers");
-    }
+    assertV2ActivationBlock(sourceBlockNumber);
 
     if (transfer.type !== "nevm-to-sys") {
       throw new Error("UTXO claim gas sponsorship is only for NEVM to SYS");

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -127,20 +127,11 @@ export class SponsorWalletService {
     );
 
     if (existingTransaction?.transaction?.hash) {
-      if (
-        action === SUBMIT_PROOFS_ACTION &&
-        existingTransaction.sourceTxHash?.toLowerCase() !== normalizedSource
-      ) {
-        throw new SponsorNonceRecoveryError(
-          "Legacy or mismatched signed sponsorship cannot be reused in V2"
-        );
-      }
-      if (!existingTransaction.walletId) {
-        throw new SponsorNonceRecoveryError(
-          "Signed sponsorship is missing its sponsor wallet identity"
-        );
-      }
-      await this.recoverSponsorNonceQueue(existingTransaction.walletId);
+      await this.recoverExistingSponsorTransaction(
+        existingTransaction,
+        action,
+        normalizedSource
+      );
       return existingTransaction;
     }
 
@@ -180,6 +171,11 @@ export class SponsorWalletService {
       placeholder = placeholderResult.transaction;
 
       if (placeholder.transaction?.hash) {
+        await this.recoverExistingSponsorTransaction(
+          placeholder,
+          action,
+          normalizedSource
+        );
         return placeholder;
       }
 
@@ -206,6 +202,11 @@ export class SponsorWalletService {
             reservationQuery
           );
           if (inFlight?.transaction?.hash) {
+            await this.recoverExistingSponsorTransaction(
+              inFlight,
+              action,
+              normalizedSource
+            );
             return inFlight;
           }
           throw new SponsorshipInProgressError();
@@ -356,14 +357,17 @@ export class SponsorWalletService {
         transfer.id,
         targetAmountSats + UTXO_CLAIM_GAS_FEE_BUFFER_SATS
       );
-      placeholder = await this.beginUtxoSponsorBroadcast(placeholder);
-      broadcastStarted = true;
-      const txid = await this.sendUtxoClaimGas(
+      const preparedTransaction = await this.prepareUtxoClaimGas(
         sponsorAddress,
-        sponsorWif,
         transfer.utxoAddress,
         targetAmountSats,
         reservation.utxo
+      );
+      placeholder = await this.beginUtxoSponsorBroadcast(placeholder);
+      broadcastStarted = true;
+      const txid = await this.sendPreparedUtxoClaimGas(
+        preparedTransaction,
+        sponsorWif,
       );
 
       await this.commitUtxoSponsorTransaction(placeholder, txid);
@@ -698,6 +702,28 @@ export class SponsorWalletService {
     }
   }
 
+  private async recoverExistingSponsorTransaction(
+    sponsorTransaction: ISponsorWalletTransaction,
+    action: SponsorWalletTransactionAction,
+    normalizedSource?: string
+  ): Promise<void> {
+    if (
+      action === SUBMIT_PROOFS_ACTION &&
+      sponsorTransaction.sourceTxHash?.toLowerCase() !== normalizedSource
+    ) {
+      throw new SponsorNonceRecoveryError(
+        "Legacy or mismatched signed sponsorship cannot be reused in V2"
+      );
+    }
+    if (!sponsorTransaction.walletId) {
+      throw new SponsorNonceRecoveryError(
+        "Signed sponsorship is missing its sponsor wallet identity"
+      );
+    }
+
+    await this.recoverSponsorNonceQueue(sponsorTransaction.walletId);
+  }
+
   private async commitSignedSponsorTransaction(
     placeholder: ISponsorWalletTransaction,
     sourceTxHash: string | undefined,
@@ -1016,13 +1042,12 @@ export class SponsorWalletService {
     );
   }
 
-  private async sendUtxoClaimGas(
+  private async prepareUtxoClaimGas(
     sponsorAddress: string,
-    sponsorWif: string,
     recipientAddress: string,
     amountSats: number,
     sponsorUtxo: SponsorUtxo
-  ): Promise<string> {
+  ): Promise<{ syscoinInstance: any; psbt: any }> {
     const syscoinInstance = new syscoin(
       null,
       getUtxoBlockbookUrl(),
@@ -1045,10 +1070,18 @@ export class SponsorWalletService {
       [sponsorUtxo]
     );
 
-    const signedPsbt = await syscoinInstance.signAndSendWithWIF(
-      result.psbt,
-      sponsorWif
-    );
+    return { syscoinInstance, psbt: result.psbt };
+  }
+
+  private async sendPreparedUtxoClaimGas(
+    preparedTransaction: { syscoinInstance: any; psbt: any },
+    sponsorWif: string
+  ): Promise<string> {
+    const signedPsbt =
+      await preparedTransaction.syscoinInstance.signAndSendWithWIF(
+        preparedTransaction.psbt,
+        sponsorWif
+      );
     const psbt = signedPsbt.psbt ?? signedPsbt;
     const transaction = psbt.extractTransaction();
 

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -135,7 +135,12 @@ export class SponsorWalletService {
           "Legacy or mismatched signed sponsorship cannot be reused in V2"
         );
       }
-      await this.broadcastSponsorTransaction(existingTransaction);
+      if (!existingTransaction.walletId) {
+        throw new SponsorNonceRecoveryError(
+          "Signed sponsorship is missing its sponsor wallet identity"
+        );
+      }
+      await this.recoverSponsorNonceQueue(existingTransaction.walletId);
       return existingTransaction;
     }
 

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -830,12 +830,20 @@ export class SponsorWalletService {
       status: { $in: ["pending", "failed"] },
       sourceTxHash: { $type: "string" },
       "transaction.rawData": { $type: "string" },
-      "transaction.nonce": { $gte: pendingNonce },
+      "transaction.nonce": { $type: "number" },
     }).sort({ "transaction.nonce": 1 });
 
     for (const pendingTransaction of pendingTransactions) {
       const storedNonce = pendingTransaction.transaction.nonce;
       if (storedNonce < pendingNonce) {
+        const knownTransaction = await web3.eth.getTransaction(
+          pendingTransaction.transaction.hash
+        );
+        if (!knownTransaction) {
+          throw new SponsorNonceRecoveryError(
+            `Sponsor transaction ${pendingTransaction.transaction.hash} was replaced at nonce ${storedNonce}; manual reconciliation is required`
+          );
+        }
         continue;
       }
       if (storedNonce > pendingNonce) {

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -364,6 +364,7 @@ export class SponsorWalletService {
         reservation.utxo
       );
       placeholder = await this.beginUtxoSponsorBroadcast(placeholder);
+      await this.markSponsorUtxoBroadcasting(reservation.key);
       broadcastStarted = true;
       const txid = await this.sendPreparedUtxoClaimGas(
         preparedTransaction,
@@ -385,7 +386,7 @@ export class SponsorWalletService {
       }
       throw error;
     } finally {
-      if (reservation) {
+      if (reservation && !broadcastStarted) {
         await this.releaseSponsorUtxoReservation(reservation.key);
       }
     }
@@ -1128,8 +1129,8 @@ export class SponsorWalletService {
   }
 
   private async markSponsorUtxoSpent(key: string) {
-    await SponsorUtxoReservation.updateOne(
-      { key },
+    const result = await SponsorUtxoReservation.updateOne(
+      { key, status: "broadcasting" },
       {
         $set: {
           status: "spent",
@@ -1137,6 +1138,22 @@ export class SponsorWalletService {
         },
       }
     );
+    if (result.modifiedCount !== 1) {
+      throw new Error("UTXO sponsor reservation was lost after broadcast");
+    }
+  }
+
+  private async markSponsorUtxoBroadcasting(key: string) {
+    const result = await SponsorUtxoReservation.updateOne(
+      { key, status: "reserved" },
+      {
+        $set: { status: "broadcasting" },
+        $unset: { expiresAt: "" },
+      }
+    );
+    if (result.modifiedCount !== 1) {
+      throw new SponsorshipInProgressError();
+    }
   }
 
   private async releaseSponsorUtxoReservation(key: string) {

--- a/api/services/transfer.ts
+++ b/api/services/transfer.ts
@@ -1,6 +1,57 @@
 import { COMMON_STATUS, ITransfer } from "@contexts/Transfer/types";
 import TransferModel from "models/transfer";
+import { createHash, timingSafeEqual } from "crypto";
 import { SponsorWalletService } from "./sponsor-wallet";
+
+export class TransferWriteUnauthorizedError extends Error {
+  constructor() {
+    super("Transfer write is not authorized");
+    this.name = "TransferWriteUnauthorizedError";
+    Object.setPrototypeOf(this, TransferWriteUnauthorizedError.prototype);
+  }
+}
+
+type TransferWriteResult = {
+  transfer: ITransfer;
+};
+
+const hashWriteToken = (writeToken: string) =>
+  createHash("sha256").update(writeToken, "utf8").digest("hex");
+
+const writeTokenMatches = (writeToken: string, expectedHash: string) => {
+  const actual = Uint8Array.from(
+    Buffer.from(hashWriteToken(writeToken), "hex")
+  );
+  const expected = Uint8Array.from(Buffer.from(expectedHash, "hex"));
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+};
+
+const toTransferUpdate = (transfer: ITransfer) => ({
+  type: transfer.type,
+  status: transfer.status,
+  logs: transfer.logs,
+  utxoAddress: transfer.utxoAddress,
+  utxoXpub: transfer.utxoXpub,
+  nevmAddress: transfer.nevmAddress,
+  amount: transfer.amount,
+  agreedToTerms: transfer.agreedToTerms,
+  useSysx: transfer.useSysx,
+  utxoAssetType: transfer.utxoAssetType,
+  updatedAt: Date.now(),
+});
+
+const toPublicTransfer = (transfer: unknown): ITransfer => {
+  const source =
+    typeof transfer === "object" &&
+    transfer !== null &&
+    "toObject" in transfer &&
+    typeof transfer.toObject === "function"
+      ? transfer.toObject()
+      : { ...(transfer as Record<string, unknown>) };
+  delete source.writeTokenHash;
+  delete source.__v;
+  return source as ITransfer;
+};
 
 export class TransferService {
   private sponsorWalletService = new SponsorWalletService();
@@ -33,7 +84,7 @@ export class TransferService {
     return transfer as unknown as ITransfer;
   }
 
-  async upsertTransfer(transfer: ITransfer): Promise<ITransfer> {
+  private async updateSponsorStatuses(transfer: ITransfer): Promise<void> {
     const submitProofsTxLog = transfer.logs.find(
       (log) => log.status === "submit-proofs"
     );
@@ -56,18 +107,52 @@ export class TransferService {
         );
       }
     }
-    const results = await TransferModel.updateOne(
-      { id: transfer.id },
-      { ...transfer, updatedAt: Date.now() },
-      { upsert: true }
+  }
+
+  async upsertTransfer(
+    transfer: ITransfer,
+    writeToken?: string
+  ): Promise<TransferWriteResult> {
+    const existing = await TransferModel.findOne({ id: transfer.id }).select(
+      "+writeTokenHash"
     );
 
-    if (!results.acknowledged) {
-      throw new Error("Transfer not updated");
+    if (!existing) {
+      if (!writeToken) {
+        throw new TransferWriteUnauthorizedError();
+      }
+      const created = await TransferModel.create({
+        ...toTransferUpdate(transfer),
+        id: transfer.id,
+        version: "v2",
+        createdAt: Date.now(),
+        writeTokenHash: hashWriteToken(writeToken),
+      });
+
+      return { transfer: toPublicTransfer(created) };
     }
 
-    const updatedTransfer = await TransferModel.findOne({ id: transfer.id });
+    if (
+      !writeToken ||
+      !existing.writeTokenHash ||
+      !writeTokenMatches(writeToken, existing.writeTokenHash)
+    ) {
+      throw new TransferWriteUnauthorizedError();
+    }
 
-    return updatedTransfer as ITransfer;
+    await this.updateSponsorStatuses(transfer);
+    const updatedTransfer = await TransferModel.findOneAndUpdate(
+      {
+        id: transfer.id,
+        writeTokenHash: existing.writeTokenHash,
+      },
+      { $set: toTransferUpdate(transfer) },
+      { new: true }
+    );
+    if (!updatedTransfer) {
+      throw new TransferWriteUnauthorizedError();
+    }
+
+    return { transfer: toPublicTransfer(updatedTransfer) };
   }
 }

--- a/components/Bridge/context/TransferContext.tsx
+++ b/components/Bridge/context/TransferContext.tsx
@@ -46,6 +46,17 @@ const buildTransferPath = (id: string) => {
   return `/api/transfer/${encodeURIComponent(id)}`;
 };
 
+const getOrCreateTransferWriteToken = (id: string) => {
+  const storageKey = `transfer-write-token-${id}`;
+  const existing = localStorage.getItem(storageKey);
+  if (existing) {
+    return existing;
+  }
+  const writeToken = crypto.randomUUID();
+  localStorage.setItem(storageKey, writeToken);
+  return writeToken;
+};
+
 export const TransferContextProvider: React.FC<
   TransferContextProviderProps
 > = ({ children, transfer: initialData }) => {
@@ -71,11 +82,13 @@ export const TransferContextProvider: React.FC<
     ["transfer", initialData.id],
     async (updatedTransfer: ITransfer) => {
       const url = buildTransferPath(initialData.id);
+      const writeToken = getOrCreateTransferWriteToken(initialData.id);
       const res = await fetch(url, {
         method: "PATCH",
         body: JSON.stringify(updatedTransfer),
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${writeToken}`,
         },
       });
       const jsonData = await res.json();

--- a/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
+++ b/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
@@ -1,60 +1,28 @@
 import { ITransfer } from "@contexts/Transfer/types";
 import { useMutation } from "react-query";
-import { useWeb3 } from "../context/Web";
-import { ISponsorWalletTransaction } from "models/sponsor-wallet-transactions";
 import { buildApiUrl } from "utils/api-base-url";
 
 const useSyscoinSubmitProofs = (
   transfer: ITransfer,
   onSuccess: (hash: string) => void
 ) => {
-  const web3 = useWeb3();
   return useMutation(
     ["syscoin-submit-proofs", transfer.id],
     async () => {
-      const sponsorWalletTransaction: ISponsorWalletTransaction = await fetch(
-        buildApiUrl(
-          `/api/transfer/${transfer.id}/signed-submit-proofs-tx`
-        )
+      const sponsorWalletTransaction: {
+        transaction: { hash: string };
+      } = await fetch(
+        buildApiUrl(`/api/transfer/${transfer.id}/signed-submit-proofs-tx`)
       ).then((res) => {
         if (res.ok) {
           return res.json();
         }
         return res.json().then(({ message }) => Promise.reject(message));
       });
-      const receipt = await web3.eth.getTransactionReceipt(
-        sponsorWalletTransaction.transaction.hash,
-      );
 
-      if (receipt) {
-        return receipt.transactionHash;
-      }
-
-      return new Promise<string>((resolve, reject) => {
-        const method = web3.eth.sendSignedTransaction(
-          sponsorWalletTransaction.transaction.rawData
-        );
-        method
-          .once("transactionHash", (hash: string | any) => {
-            // Handle both string and object formats
-            const txHash = typeof hash === "string" ? hash : hash?.hash;
-            
-            if (!txHash) {
-              reject("Failed to submit proofs. Check browser logs");
-              console.error("Submission failed", hash);
-            } else {
-              resolve(txHash);
-            }
-          })
-          .on("error", (error: { message: string }) => {
-            if (/might still be mined/.test(error.message)) {
-              resolve("");
-            } else {
-              console.error(error);
-              reject(error);
-            }
-          });
-      });
+      // The backend durably stores and broadcasts the signed transaction before
+      // returning. The browser only observes the accepted transaction hash.
+      return sponsorWalletTransaction.transaction.hash;
     },
     {
       onSuccess: (data: string) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   roots: ['<rootDir>'],
+  testPathIgnorePatterns: ['<rootDir>/.next/'],
   modulePaths: [compilerOptions.baseUrl], // <-- This will be set to 'baseUrl' value
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
 }

--- a/models/__tests__/ensure-sponsor-indexes.test.ts
+++ b/models/__tests__/ensure-sponsor-indexes.test.ts
@@ -23,6 +23,10 @@ const sponsorUtxoReservation: any = {
 const sponsorRateLimit: any = {
   createIndexes: jest.fn(),
 };
+const transferModel: any = {
+  aggregate: jest.fn(),
+  createIndexes: jest.fn(),
+};
 
 jest.mock("../sponsor-wallet-transactions", () => ({
   __esModule: true,
@@ -36,6 +40,10 @@ jest.mock("../sponsor-rate-limit", () => ({
   __esModule: true,
   default: sponsorRateLimit,
 }));
+jest.mock("../transfer", () => ({
+  __esModule: true,
+  default: transferModel,
+}));
 
 import { ensureSponsorIndexes } from "../ensure-sponsor-indexes";
 
@@ -46,9 +54,12 @@ describe("ensureSponsorIndexes", () => {
     delete process.env.NEVM_V2_ACTIVATION_BLOCK;
     sponsorWalletTransactions.countDocuments.mockResolvedValue(0);
     sponsorWalletTransactions.aggregate.mockResolvedValue([]);
+    collection.indexes.mockResolvedValue([]);
     sponsorWalletTransactions.createIndexes.mockResolvedValue(undefined);
     sponsorUtxoReservation.createIndexes.mockResolvedValue(undefined);
     sponsorRateLimit.createIndexes.mockResolvedValue(undefined);
+    transferModel.aggregate.mockResolvedValue([]);
+    transferModel.createIndexes.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -77,6 +88,7 @@ describe("ensureSponsorIndexes", () => {
     expect(sponsorWalletTransactions.createIndexes).toHaveBeenCalledTimes(1);
     expect(sponsorUtxoReservation.createIndexes).toHaveBeenCalledTimes(1);
     expect(sponsorRateLimit.createIndexes).toHaveBeenCalledTimes(1);
+    expect(transferModel.createIndexes).toHaveBeenCalledTimes(1);
   });
 
   it("does not hide unexpected index cleanup failures", async () => {
@@ -140,6 +152,18 @@ describe("ensureSponsorIndexes", () => {
       "NEVM V2 activation block is not configured"
     );
     expect(sponsorWalletTransactions.countDocuments).not.toHaveBeenCalled();
+    expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
+  });
+
+  it("blocks startup until duplicate transfer ids are reconciled", async () => {
+    transferModel.aggregate.mockResolvedValue([
+      { _id: "duplicate-transfer", count: 2 },
+    ]);
+
+    await expect(ensureSponsorIndexes()).rejects.toThrow(
+      "reconcile duplicate transfer ids"
+    );
+    expect(transferModel.createIndexes).not.toHaveBeenCalled();
     expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
   });
 });

--- a/models/__tests__/ensure-sponsor-indexes.test.ts
+++ b/models/__tests__/ensure-sponsor-indexes.test.ts
@@ -43,6 +43,7 @@ describe("ensureSponsorIndexes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.FOUNDATION_FUNDED;
+    delete process.env.NEVM_V2_ACTIVATION_BLOCK;
     sponsorWalletTransactions.countDocuments.mockResolvedValue(0);
     sponsorWalletTransactions.aggregate.mockResolvedValue([]);
     sponsorWalletTransactions.createIndexes.mockResolvedValue(undefined);
@@ -52,6 +53,7 @@ describe("ensureSponsorIndexes", () => {
 
   afterEach(() => {
     delete process.env.FOUNDATION_FUNDED;
+    delete process.env.NEVM_V2_ACTIVATION_BLOCK;
   });
 
   it("ignores a legacy index already dropped by another cold start", async () => {
@@ -93,6 +95,7 @@ describe("ensureSponsorIndexes", () => {
 
   it("blocks foundation funding until legacy signed rows are reconciled", async () => {
     process.env.FOUNDATION_FUNDED = "true";
+    process.env.NEVM_V2_ACTIVATION_BLOCK = "100";
     sponsorWalletTransactions.countDocuments.mockResolvedValue(1);
 
     await expect(ensureSponsorIndexes()).rejects.toThrow(
@@ -119,6 +122,7 @@ describe("ensureSponsorIndexes", () => {
 
   it("blocks foundation funding when legacy rows share a sponsor nonce", async () => {
     process.env.FOUNDATION_FUNDED = "true";
+    process.env.NEVM_V2_ACTIVATION_BLOCK = "100";
     sponsorWalletTransactions.aggregate.mockResolvedValue([
       { _id: { walletId: "0xSponsor", nonce: 3 }, count: 2 },
     ]);
@@ -126,6 +130,16 @@ describe("ensureSponsorIndexes", () => {
     await expect(ensureSponsorIndexes()).rejects.toThrow(
       "Foundation funding V2 cutover blocked"
     );
+    expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
+  });
+
+  it("blocks foundation funding when the V2 activation block is absent", async () => {
+    process.env.FOUNDATION_FUNDED = "true";
+
+    await expect(ensureSponsorIndexes()).rejects.toThrow(
+      "NEVM V2 activation block is not configured"
+    );
+    expect(sponsorWalletTransactions.countDocuments).not.toHaveBeenCalled();
     expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
   });
 });

--- a/models/__tests__/ensure-sponsor-indexes.test.ts
+++ b/models/__tests__/ensure-sponsor-indexes.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 
 const collection: any = {
   indexes: jest.fn(),
@@ -7,6 +14,8 @@ const collection: any = {
 const sponsorWalletTransactions: any = {
   collection,
   createIndexes: jest.fn(),
+  countDocuments: jest.fn(),
+  aggregate: jest.fn(),
 };
 const sponsorUtxoReservation: any = {
   createIndexes: jest.fn(),
@@ -33,9 +42,16 @@ import { ensureSponsorIndexes } from "../ensure-sponsor-indexes";
 describe("ensureSponsorIndexes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.FOUNDATION_FUNDED;
+    sponsorWalletTransactions.countDocuments.mockResolvedValue(0);
+    sponsorWalletTransactions.aggregate.mockResolvedValue([]);
     sponsorWalletTransactions.createIndexes.mockResolvedValue(undefined);
     sponsorUtxoReservation.createIndexes.mockResolvedValue(undefined);
     sponsorRateLimit.createIndexes.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.FOUNDATION_FUNDED;
   });
 
   it("ignores a legacy index already dropped by another cold start", async () => {
@@ -72,6 +88,44 @@ describe("ensureSponsorIndexes", () => {
     collection.dropIndex.mockRejectedValue(databaseError);
 
     await expect(ensureSponsorIndexes()).rejects.toBe(databaseError);
+    expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
+  });
+
+  it("blocks foundation funding until legacy signed rows are reconciled", async () => {
+    process.env.FOUNDATION_FUNDED = "true";
+    sponsorWalletTransactions.countDocuments.mockResolvedValue(1);
+
+    await expect(ensureSponsorIndexes()).rejects.toThrow(
+      "Foundation funding V2 cutover blocked"
+    );
+
+    expect(sponsorWalletTransactions.countDocuments).toHaveBeenCalledWith({
+      "transaction.rawData": { $type: "string" },
+      "transaction.nonce": { $type: "number" },
+      $or: [
+        { action: { $exists: false } },
+        {
+          action: "submit-proofs",
+          sourceTxHash: { $exists: false },
+        },
+        {
+          action: "submit-proofs",
+          sourceTxHash: null,
+        },
+      ],
+    });
+    expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
+  });
+
+  it("blocks foundation funding when legacy rows share a sponsor nonce", async () => {
+    process.env.FOUNDATION_FUNDED = "true";
+    sponsorWalletTransactions.aggregate.mockResolvedValue([
+      { _id: { walletId: "0xSponsor", nonce: 3 }, count: 2 },
+    ]);
+
+    await expect(ensureSponsorIndexes()).rejects.toThrow(
+      "Foundation funding V2 cutover blocked"
+    );
     expect(sponsorWalletTransactions.createIndexes).not.toHaveBeenCalled();
   });
 });

--- a/models/__tests__/sponsor-wallet-transactions.test.ts
+++ b/models/__tests__/sponsor-wallet-transactions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import SponsorWalletTransactions from "../sponsor-wallet-transactions";
+
+describe("SponsorWalletTransactions indexes", () => {
+  it("serializes V2 submit-proofs nonce commits per sponsor wallet", () => {
+    const nonceIndex = SponsorWalletTransactions.schema
+      .indexes()
+      .find(
+        ([, options]) =>
+          options.name ===
+          "walletId_1_transaction_nonce_1_submit_proofs_v2"
+      );
+
+    expect(nonceIndex).toEqual([
+      { walletId: 1, "transaction.nonce": 1 },
+      expect.objectContaining({
+        unique: true,
+        partialFilterExpression: {
+          action: "submit-proofs",
+          sponsorProtocolVersion: 2,
+          walletId: { $type: "string" },
+          "transaction.nonce": { $type: "number" },
+        },
+      }),
+    ]);
+  });
+});

--- a/models/__tests__/transfer.test.ts
+++ b/models/__tests__/transfer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "@jest/globals";
+import TransferModel from "../transfer";
+
+describe("Transfer model administrative compatibility", () => {
+  it("allows an administrator to save an existing V1 row without a public write token", () => {
+    const transfer = new TransferModel({
+      id: "legacy-transfer",
+      type: "nevm-to-sys",
+      status: "completed",
+      logs: [],
+      createdAt: 1,
+      version: "v1",
+    });
+
+    expect(transfer.validateSync()).toBeUndefined();
+  });
+});

--- a/models/ensure-sponsor-indexes.ts
+++ b/models/ensure-sponsor-indexes.ts
@@ -1,3 +1,4 @@
+import { getV2ActivationBlock } from "api/services/sponsor-eligibility";
 import SponsorRateLimit from "./sponsor-rate-limit";
 import SponsorUtxoReservation from "./sponsor-utxo-reservation";
 import SponsorWalletTransactions from "./sponsor-wallet-transactions";
@@ -53,6 +54,7 @@ const assertFoundationFundingCutoverIsSafe = async () => {
   if (process.env.FOUNDATION_FUNDED !== "true") {
     return;
   }
+  getV2ActivationBlock();
 
   const unsafeLegacySignedRows =
     await SponsorWalletTransactions.countDocuments({

--- a/models/ensure-sponsor-indexes.ts
+++ b/models/ensure-sponsor-indexes.ts
@@ -49,7 +49,58 @@ const dropConflictingSourceTxHashIndexes = async () => {
   }
 };
 
+const assertFoundationFundingCutoverIsSafe = async () => {
+  if (process.env.FOUNDATION_FUNDED !== "true") {
+    return;
+  }
+
+  const unsafeLegacySignedRows =
+    await SponsorWalletTransactions.countDocuments({
+      "transaction.rawData": { $type: "string" },
+      "transaction.nonce": { $type: "number" },
+      $or: [
+        { action: { $exists: false } },
+        {
+          action: "submit-proofs",
+          sourceTxHash: { $exists: false },
+        },
+        {
+          action: "submit-proofs",
+          sourceTxHash: null,
+        },
+      ],
+    });
+  const duplicateSignedNonces = await SponsorWalletTransactions.aggregate([
+    {
+      $match: {
+        action: "submit-proofs",
+        walletId: { $type: "string" },
+        "transaction.rawData": { $type: "string" },
+        "transaction.nonce": { $type: "number" },
+      },
+    },
+    {
+      $group: {
+        _id: {
+          walletId: "$walletId",
+          nonce: "$transaction.nonce",
+        },
+        count: { $sum: 1 },
+      },
+    },
+    { $match: { count: { $gt: 1 } } },
+    { $limit: 1 },
+  ]);
+
+  if (unsafeLegacySignedRows > 0 || duplicateSignedNonces.length > 0) {
+    throw new Error(
+      "Foundation funding V2 cutover blocked: reconcile legacy signed sponsor rows with missing identity or duplicate nonces before enabling FOUNDATION_FUNDED"
+    );
+  }
+};
+
 export const ensureSponsorIndexes = async () => {
+  await assertFoundationFundingCutoverIsSafe();
   await dropConflictingSourceTxHashIndexes();
   await Promise.all([
     SponsorWalletTransactions.createIndexes(),

--- a/models/ensure-sponsor-indexes.ts
+++ b/models/ensure-sponsor-indexes.ts
@@ -2,6 +2,7 @@ import { getV2ActivationBlock } from "api/services/sponsor-eligibility";
 import SponsorRateLimit from "./sponsor-rate-limit";
 import SponsorUtxoReservation from "./sponsor-utxo-reservation";
 import SponsorWalletTransactions from "./sponsor-wallet-transactions";
+import TransferModel from "./transfer";
 
 const hasMongoError = (
   error: unknown,
@@ -101,10 +102,27 @@ const assertFoundationFundingCutoverIsSafe = async () => {
   }
 };
 
+const assertTransferIdsAreUnique = async () => {
+  const duplicateTransferIds = await TransferModel.aggregate([
+    { $match: { id: { $type: "string" } } },
+    { $group: { _id: "$id", count: { $sum: 1 } } },
+    { $match: { count: { $gt: 1 } } },
+    { $limit: 1 },
+  ]);
+
+  if (duplicateTransferIds.length > 0) {
+    throw new Error(
+      "V2 transfer cutover blocked: reconcile duplicate transfer ids before serving public writes"
+    );
+  }
+};
+
 export const ensureSponsorIndexes = async () => {
+  await assertTransferIdsAreUnique();
   await assertFoundationFundingCutoverIsSafe();
   await dropConflictingSourceTxHashIndexes();
   await Promise.all([
+    TransferModel.createIndexes(),
     SponsorWalletTransactions.createIndexes(),
     SponsorUtxoReservation.createIndexes(),
     SponsorRateLimit.createIndexes(),

--- a/models/sponsor-utxo-reservation.ts
+++ b/models/sponsor-utxo-reservation.ts
@@ -1,6 +1,10 @@
 import mongoose from "mongoose";
 
-export type SponsorUtxoReservationStatus = "reserved" | "spent" | "released";
+export type SponsorUtxoReservationStatus =
+  | "reserved"
+  | "broadcasting"
+  | "spent"
+  | "released";
 
 export interface ISponsorUtxoReservation extends mongoose.Document {
   key: string;
@@ -8,7 +12,7 @@ export interface ISponsorUtxoReservation extends mongoose.Document {
   txid: string;
   vout: number;
   status: SponsorUtxoReservationStatus;
-  expiresAt: Date;
+  expiresAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -40,7 +44,6 @@ const SponsorUtxoReservationSchema =
       },
       expiresAt: {
         type: Date,
-        required: true,
       },
     },
     { timestamps: true }

--- a/models/sponsor-wallet-transactions.ts
+++ b/models/sponsor-wallet-transactions.ts
@@ -12,8 +12,13 @@ export interface ISponsorWalletTransaction extends mongoose.Document {
   transferId: string;
   action: SponsorWalletTransactionAction;
   sourceTxHash?: string;
+  sponsorProtocolVersion?: number;
   walletId: string;
   status: SponsorWalletTransactionStatus;
+  reservationOwner?: string;
+  reservationExpiresAt?: Date;
+  broadcastAt?: Date;
+  broadcastAttempts?: number;
   createdAt: Date;
   updatedAt: Date;
   transaction: {
@@ -39,6 +44,9 @@ const SponsorWalletTransactionSchema =
       sourceTxHash: {
         type: String,
       },
+      sponsorProtocolVersion: {
+        type: Number,
+      },
       walletId: {
         type: String,
       },
@@ -49,6 +57,19 @@ const SponsorWalletTransactionSchema =
       transaction: {
         type: Object,
         default: {},
+      },
+      reservationOwner: {
+        type: String,
+      },
+      reservationExpiresAt: {
+        type: Date,
+      },
+      broadcastAt: {
+        type: Date,
+      },
+      broadcastAttempts: {
+        type: Number,
+        default: 0,
       },
     },
     { timestamps: true }
@@ -68,6 +89,21 @@ SponsorWalletTransactionSchema.index(
     unique: true,
     partialFilterExpression: {
       sourceTxHash: { $type: "string" },
+    },
+  }
+);
+// Serialize NEVM sponsor nonce commits across concurrent API workers. A raw
+// transaction must be durable under this index before the server broadcasts it.
+SponsorWalletTransactionSchema.index(
+  { walletId: 1, "transaction.nonce": 1 },
+  {
+    name: "walletId_1_transaction_nonce_1_submit_proofs_v2",
+    unique: true,
+    partialFilterExpression: {
+      action: "submit-proofs",
+      sponsorProtocolVersion: 2,
+      walletId: { $type: "string" },
+      "transaction.nonce": { $type: "number" },
     },
   }
 );

--- a/models/sponsor-wallet-transactions.ts
+++ b/models/sponsor-wallet-transactions.ts
@@ -17,6 +17,7 @@ export interface ISponsorWalletTransaction extends mongoose.Document {
   status: SponsorWalletTransactionStatus;
   reservationOwner?: string;
   reservationExpiresAt?: Date;
+  reservationPhase?: "reserved" | "broadcasting";
   broadcastAt?: Date;
   broadcastAttempts?: number;
   createdAt: Date;
@@ -63,6 +64,10 @@ const SponsorWalletTransactionSchema =
       },
       reservationExpiresAt: {
         type: Date,
+      },
+      reservationPhase: {
+        type: String,
+        enum: ["reserved", "broadcasting"],
       },
       broadcastAt: {
         type: Date,

--- a/models/transfer.ts
+++ b/models/transfer.ts
@@ -1,7 +1,10 @@
 import { ITransfer, ITransferLog } from "@contexts/Transfer/types";
 import mongoose from "mongoose";
 
-export type Transfer = mongoose.Document & ITransfer;
+export type Transfer = mongoose.Document &
+  ITransfer & {
+    writeTokenHash?: string;
+  };
 
 const TransferLogSchema = new mongoose.Schema<ITransferLog>({
   date: {
@@ -18,6 +21,8 @@ const TransferLogSchema = new mongoose.Schema<ITransferLog>({
 const TransferSchema = new mongoose.Schema<Transfer>({
   id: {
     type: String,
+    required: true,
+    unique: true,
   },
   type: {
     type: String,
@@ -43,6 +48,8 @@ const TransferSchema = new mongoose.Schema<Transfer>({
   },
   version: {
     type: String,
+    required: true,
+    enum: ["v2"],
   },
   amount: {
     type: String,
@@ -55,6 +62,11 @@ const TransferSchema = new mongoose.Schema<Transfer>({
   },
   utxoAssetType: {
     type: String,
+  },
+  writeTokenHash: {
+    type: String,
+    required: true,
+    select: false,
   },
 });
 

--- a/models/transfer.ts
+++ b/models/transfer.ts
@@ -49,7 +49,7 @@ const TransferSchema = new mongoose.Schema<Transfer>({
   version: {
     type: String,
     required: true,
-    enum: ["v2"],
+    enum: ["v1", "v2"],
   },
   amount: {
     type: String,
@@ -65,7 +65,6 @@ const TransferSchema = new mongoose.Schema<Transfer>({
   },
   writeTokenHash: {
     type: String,
-    required: true,
     select: false,
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/pages/api/transfer/[id].ts
+++ b/pages/api/transfer/[id].ts
@@ -1,5 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { TransferService } from "api/services/transfer";
+import {
+  TransferService,
+  TransferWriteUnauthorizedError,
+} from "api/services/transfer";
 import dbConnect from "lib/mongodb";
 import { applyApiCors } from "utils/api/cors";
 
@@ -16,21 +19,36 @@ const getRequest = async (req: NextApiRequest, res: NextApiResponse) => {
   return res.status(200).json(transfer);
 };
 
-const patchRequest = async (req: NextApiRequest, res: NextApiResponse) => {
+export const patchRequest = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
   const id = req.query.id as string;
 
   if (!id) {
     return res.status(400).json({ message: "Missing id" });
   }
+  if (!req.body || req.body.id !== id) {
+    return res.status(400).json({ message: "Transfer id does not match URL" });
+  }
 
   try {
-    const updated = await transferService.upsertTransfer(req.body);
-    res.status(200).json(updated);
+    const authorization = req.headers.authorization;
+    const writeToken =
+      typeof authorization === "string" &&
+      authorization.startsWith("Bearer ")
+        ? authorization.slice("Bearer ".length)
+        : undefined;
+    const updated = await transferService.upsertTransfer(req.body, writeToken);
+    res.status(200).json(updated.transfer);
   } catch (e) {
+    if (e instanceof TransferWriteUnauthorizedError) {
+      return res.status(401).json({ message: e.message });
+    }
     if (e instanceof Error) {
-      res.status(500).json({ message: e.message });
+      return res.status(500).json({ message: e.message });
     } else {
-      res.status(500).json({ message: "Unknown error" });
+      return res.status(500).json({ message: "Unknown error" });
     }
   }
 };

--- a/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
+++ b/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
@@ -1,6 +1,7 @@
 import { RELAY_CONTRACT_ADDRESS } from "@constants";
 import relayAbi from "@contexts/Transfer/relay-abi";
 import SponsorWalletService, {
+  SponsorNonceRecoveryError,
   SponsorshipInProgressError,
   syscoinTxIdFromWitnessStrippedHex,
 } from "api/services/sponsor-wallet";
@@ -38,6 +39,9 @@ const handler: NextApiHandler = async (
     }
     await dbConnect();
     const transfer = await transferService.getTransfer(id as string);
+    if (transfer.version !== "v2") {
+      throw new Error("Foundation sponsorship is only available for V2 transfers");
+    }
     const generatedProofLog = transfer.logs.find(
       (a) => a.status === "generate-proofs"
     );
@@ -91,15 +95,25 @@ const handler: NextApiHandler = async (
       sourceTxHash
     );
 
-    res.status(200).json(sponsoredTransaction.toJSON({ versionKey: false }));
+    res.status(200).json({
+      status: sponsoredTransaction.status,
+      transaction: {
+        hash: sponsoredTransaction.transaction.hash,
+        confirmedHash: sponsoredTransaction.transaction.confirmedHash,
+      },
+    });
   } catch (e) {
     let message = "Unknown error";
     if (e instanceof Error) {
       message = e.message;
     }
-    res
-      .status(e instanceof SponsorshipInProgressError ? 409 : 500)
-      .json({ message });
+    const status =
+      e instanceof SponsorshipInProgressError
+        ? 409
+        : e instanceof SponsorNonceRecoveryError
+          ? 503
+          : 500;
+    res.status(status).json({ message });
   }
 };
 

--- a/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
+++ b/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
@@ -3,8 +3,8 @@ import relayAbi from "@contexts/Transfer/relay-abi";
 import SponsorWalletService, {
   SponsorNonceRecoveryError,
   SponsorshipInProgressError,
-  syscoinTxIdFromWitnessStrippedHex,
 } from "api/services/sponsor-wallet";
+import { getCanonicalChainLockedProof } from "api/services/sponsor-proof";
 import { TransferService } from "api/services/transfer";
 import { getProof } from "bitcoin-proof";
 import dbConnect from "lib/mongodb";
@@ -48,7 +48,9 @@ const handler: NextApiHandler = async (
     if (!generatedProofLog) {
       throw new Error("Proofs not generated");
     }
-    const proof = generatedProofLog.payload.data as SPVProof;
+    const submittedProof = generatedProofLog.payload.data as SPVProof;
+    const { proof, sourceTxHash } =
+      await getCanonicalChainLockedProof(submittedProof);
     const nevmBlock = await web3.eth.getBlock(`0x${proof.nevm_blockhash}`);
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
@@ -80,8 +82,6 @@ const handler: NextApiHandler = async (
     );
 
     const encoded = method.encodeABI();
-    const sourceTxHash = syscoinTxIdFromWitnessStrippedHex(proof.transaction);
-
     const sponsorWalletService = new SponsorWalletService();
 
     const sponsoredTransaction = await sponsorWalletService.sponsorTransaction(

--- a/pages/api/transfer/[id]/sponsor-claim-gas.ts
+++ b/pages/api/transfer/[id]/sponsor-claim-gas.ts
@@ -148,6 +148,10 @@ const getConfirmedFreezeBurnTxHash = (
 const assertClaimGasEligible = async (
   transfer: Awaited<ReturnType<TransferService["getTransfer"]>>
 ): Promise<string> => {
+  if (transfer.version !== "v2") {
+    throw new Error("Foundation sponsorship is only available for V2 transfers");
+  }
+
   if (transfer.type !== "nevm-to-sys") {
     throw new Error("Claim gas sponsorship is only available for NEVM to SYS");
   }

--- a/pages/api/transfer/[id]/sponsor-claim-gas.ts
+++ b/pages/api/transfer/[id]/sponsor-claim-gas.ts
@@ -3,6 +3,7 @@ import { SYSX_ASSET_GUID } from "@contexts/Transfer/constants";
 import SyscoinERC20ManagerABI from "@contexts/Transfer/abi/SyscoinERC20Manager";
 import { ETH_TO_SYS_TRANSFER_STATUS } from "@contexts/Transfer/types";
 import SponsorWalletService from "api/services/sponsor-wallet";
+import { assertV2ActivationBlock } from "api/services/sponsor-eligibility";
 import { TransferService } from "api/services/transfer";
 import dbConnect from "lib/mongodb";
 import SponsorRateLimit from "models/sponsor-rate-limit";
@@ -145,13 +146,9 @@ const getConfirmedFreezeBurnTxHash = (
   return confirmedFreezeBurn.payload.data.transactionHash.toLowerCase();
 };
 
-const assertClaimGasEligible = async (
+export const assertClaimGasEligible = async (
   transfer: Awaited<ReturnType<TransferService["getTransfer"]>>
-): Promise<string> => {
-  if (transfer.version !== "v2") {
-    throw new Error("Foundation sponsorship is only available for V2 transfers");
-  }
-
+): Promise<{ blockNumber: number; transactionHash: string }> => {
   if (transfer.type !== "nevm-to-sys") {
     throw new Error("Claim gas sponsorship is only available for NEVM to SYS");
   }
@@ -185,6 +182,7 @@ const assertClaimGasEligible = async (
   if (!transaction || !receipt) {
     throw new Error("Freeze and burn transaction was not found on NEVM");
   }
+  assertV2ActivationBlock(receipt.blockNumber);
 
   const managerAddress = normalizeAddress(ERC20_MANAGER_CONTRACT_ADDRESS);
   const nevmAddress = normalizeAddress(transfer.nevmAddress);
@@ -234,7 +232,10 @@ const assertClaimGasEligible = async (
     throw new Error("Freeze and burn event does not match this transfer");
   }
 
-  return transactionHash;
+  return {
+    blockNumber: receipt.blockNumber,
+    transactionHash,
+  };
 };
 
 const applySponsorRateLimits = async (
@@ -290,7 +291,10 @@ const handler: NextApiHandler = async (
     await dbConnect();
 
     const transfer = await transferService.getTransfer(id);
-    const freezeBurnTxHash = await assertClaimGasEligible(transfer);
+    const {
+      blockNumber: freezeBurnBlockNumber,
+      transactionHash: freezeBurnTxHash,
+    } = await assertClaimGasEligible(transfer);
 
     const preflightResult =
       await sponsorWalletService.getUtxoClaimGasFundingStatus(
@@ -304,7 +308,8 @@ const handler: NextApiHandler = async (
     await applySponsorRateLimits(req, transfer);
     const result = await sponsorWalletService.sponsorUtxoClaimGas(
       transfer,
-      freezeBurnTxHash
+      freezeBurnTxHash,
+      freezeBurnBlockNumber
     );
 
     return res.status(200).json(result);

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -51,7 +51,7 @@ const createTransfer = (
   draft: Partial<ConnectValidateDraft> = {}
 ): ITransfer => ({
   amount: "0",
-  id: `${Date.now()}`,
+  id: crypto.randomUUID(),
   type,
   status: COMMON_STATUS.INITIALIZE,
   logs: [],

--- a/utils/syscoin-txid.ts
+++ b/utils/syscoin-txid.ts
@@ -1,0 +1,12 @@
+import { createHash } from "crypto";
+
+/** Bitcoin/Syscoin txid (display hex) from witness-stripped serialization. */
+export function syscoinTxIdFromWitnessStrippedHex(txHex: string): string {
+  const hex = txHex.startsWith("0x") ? txHex.slice(2) : txHex;
+  if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error("Invalid witness-stripped transaction hex");
+  }
+  const firstHash = createHash("sha256").update(hex, "hex").digest("hex");
+  const hash = createHash("sha256").update(firstHash, "hex").digest("hex");
+  return hash.match(/.{2}/g)!.reverse().join("");
+}


### PR DESCRIPTION
## Summary

- move NEVM sponsorship broadcasting entirely to the backend and return only the accepted transaction hash to the browser
- persist signed transactions before broadcasting, reconcile every durable nonce regardless of status, and fail closed on gaps, replacements, lagging RPC views, or reorged success rows
- serialize V2 nonce commits with a partial unique MongoDB index and fence stale workers with lease-owner tokens
- fence UTXO construction, broadcast, and exact-output reservations; ambiguous outcomes require manual reconciliation and cannot retry
- authorize claim-gas from the immutable NEVM receipt height using `NEVM_V2_ACTIVATION_BLOCK`, never from the stored transfer version label
- authenticate every public transfer PATCH with a per-transfer capability, bind URL and body IDs, allowlist writable fields, force new records to V2, and keep historical rows without capabilities public-read-only
- refetch sponsored SPV proofs server-side by derived txid and require a canonical ChainLocked proof before building calldata
- block startup on duplicate historical transfer IDs and synchronously create the unique ID index before serving requests
- run the full Jest regression suite as a required CI step

## Root cause

The backend previously signed nonce `n` and returned the raw transaction without broadcasting it. The browser was the only broadcaster, while the allocator selected `max(chainPendingNonce, highestStoredNonce + 1)`. A caller could withhold nonce `n`, causing every later sponsorship to sign unusable `n+1`, `n+2`, and so on.

Subsequent review also found that a client-writable V2 label could authorize a subsidy for a genuine pre-cutover TokenFreeze event, and that pre-finality proof data could be pinned by txid across a reorg. Eligibility is now derived from immutable chain state and sponsored proofs must be server-fetched and ChainLocked.

## V2 cutover

This intentionally does not support legacy bridge operation. Historical rows remain available to the authenticated admin recovery path, but public writes require the new capability. Keep foundation funding disabled while all old sponsor instances stop; configure the immutable `NEVM_V2_ACTIVATION_BLOCK`; reconcile signed legacy sponsor rows, duplicate sponsor nonces, and duplicate transfer IDs; deploy backend and frontend atomically; then enable `FOUNDATION_FUNDED=true`.

## Validation

- reproduced the withheld-nonce, pre-activation eligibility, unauthenticated PATCH, successful-row nonce rollback, admin schema, and duplicate transfer-ID regressions before their fixes
- `yarn test --runInBand` — 52 tests passed locally and in required GitHub CI
- `yarn tsc --noEmit --pretty false` — passed
- `yarn lint` — passed with one pre-existing hook dependency warning in `pages/bridge/[id].tsx`
- production build — passed locally with Sentry upload in dry-run mode and passed in GitHub CI
- final Codex review on `cf8eac6` — no major issues; all 10 review threads resolved

Fixes the release blockers identified after #71.