### PR TITLE
Prevent EVM refetches after Pali UTXO switch

### DIFF
--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo } from "react";
 import { TransactionConfig } from "web3-core";
 import Web3 from "web3";
 import { NEVMNetwork } from "../Transfer/constants";
@@ -8,6 +8,7 @@ import { usePaliWallet } from "@contexts/PaliWallet/usePaliWallet";
 import { IPaliWalletV2Context } from "@contexts/PaliWallet/V2Provider";
 import { captureException } from "@sentry/nextjs";
 import { useConstants } from "@contexts/useConstants";
+import { isPaliV2UtxoMode } from "@contexts/PaliWallet/network-query-policy";
 
 interface INEVMContext {
   account?: string;
@@ -34,8 +35,6 @@ type NEVMProviderProps = {
 };
 
 const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
-  const [isChainChangedCallbackSet, setIsChainChangedCallbackSet] =
-    useState(false);
   const { data: isEthereumAvailable } = useQuery(["nevm", "isEthAvailable"], {
     queryFn: () => {
       return typeof window.ethereum !== "undefined";
@@ -45,12 +44,19 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
 
   const metamask = useMetamask();
   const paliWallet = usePaliWallet() as IPaliWalletV2Context;
+  const isPaliEvmProvider =
+    paliWallet.version === "v2" && paliWallet.isEVMInjected;
+  const isPaliOnUtxo = isPaliV2UtxoMode(
+    paliWallet.version,
+    paliWallet.isEVMInjected,
+    paliWallet.isBitcoinBased
+  );
   const isEnabled = useMemo(() => {
     if (!isEthereumAvailable) {
       return false;
     }
     if (paliWallet.version === "v2" && paliWallet.isEVMInjected) {
-      return true;
+      return !isPaliOnUtxo;
     }
     return metamask.isEnabled;
   }, [
@@ -58,6 +64,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     paliWallet.version,
     paliWallet.isEVMInjected,
     paliWallet.isBitcoinBased,
+    isPaliOnUtxo,
     isEthereumAvailable,
   ]);
   const web3 = useMemo(() => {
@@ -133,25 +140,32 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
         .getBalance(account.data)
         .then((balance) => web3.utils.fromWei(balance || "0"));
     },
-    enabled: Boolean(isEnabled && account.isFetched && account.data),
+    enabled: Boolean(
+      isEnabled && !isPaliOnUtxo && account.isFetched && account.data
+    ),
+    refetchOnWindowFocus: false,
   });
 
   const chainId = useQuery(
     ["nevm", "chainId"],
     async () => window.ethereum.request({ method: "eth_chainId" }),
-    { 
-      enabled: isEnabled && Boolean(account.data), // Only run after account is connected
-      refetchOnMount: true, 
-      refetchOnWindowFocus: true 
+    {
+      enabled: isEnabled && !isPaliOnUtxo && Boolean(account.data),
+      refetchOnMount: true,
+      refetchOnWindowFocus: false,
     }
   );
+  const refetchChainId = chainId.refetch;
   const expectedChainId = constants?.chain_id ?? MAINNET_CHAIN_ID;
   const normalizedChainId =
     typeof chainId.data === "string" ? chainId.data.toLowerCase() : undefined;
   const normalizedExpectedChainId = expectedChainId.toLowerCase();
-  const isExpectedChain = normalizedChainId === normalizedExpectedChainId;
+  const isExpectedChain =
+    isEnabled && normalizedChainId === normalizedExpectedChainId;
   const isWrongChain = Boolean(
-    normalizedChainId && normalizedChainId !== normalizedExpectedChainId
+    isEnabled &&
+      normalizedChainId &&
+      normalizedChainId !== normalizedExpectedChainId
   );
 
   const sendTransaction = (config: TransactionConfig) => {
@@ -214,27 +228,53 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
   };
 
   useEffect(() => {
-    if (chainId.isFetched && !isChainChangedCallbackSet) {
-      window.ethereum.on("chainChanged", () => {
-        chainId.refetch();
-      });
-      setIsChainChangedCallbackSet(true);
+    if (
+      !isEnabled ||
+      isPaliEvmProvider ||
+      isPaliOnUtxo ||
+      !window.ethereum?.on
+    ) {
+      return;
     }
-  }, [chainId.isFetched, chainId, isChainChangedCallbackSet]);
+
+    const ethereumProvider = window.ethereum as typeof window.ethereum & {
+      removeListener?: (event: string, callback: () => void) => void;
+      off?: (event: string, callback: () => void) => void;
+    };
+    const handleChainChanged = () => {
+      void refetchChainId();
+    };
+
+    ethereumProvider.on("chainChanged", handleChainChanged);
+
+    return () => {
+      if (typeof ethereumProvider.removeListener === "function") {
+        ethereumProvider.removeListener("chainChanged", handleChainChanged);
+      } else if (typeof ethereumProvider.off === "function") {
+        ethereumProvider.off("chainChanged", handleChainChanged);
+      }
+    };
+  }, [isEnabled, isPaliEvmProvider, isPaliOnUtxo, refetchChainId]);
 
   return (
     <NEVMContext.Provider
       value={{
-        account: account.isSuccess && account.data ? account.data : undefined,
+        account:
+          isEnabled && account.isSuccess && account.data
+            ? account.data
+            : undefined,
         sendTransaction,
-        balance: balance.data,
+        balance: isEnabled ? balance.data : undefined,
         isTestnet: !!isTestnet,
         expectedChainId,
         isExpectedChain,
         isWrongChain,
         switchToMainnet,
         connect,
-        chainId: chainId.isSuccess && chainId.data ? chainId.data : undefined,
+        chainId:
+          isEnabled && chainId.isSuccess && chainId.data
+            ? chainId.data
+            : undefined,
         signMessage,
       }}
     >

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -8,7 +8,10 @@ import { usePaliWallet } from "@contexts/PaliWallet/usePaliWallet";
 import { IPaliWalletV2Context } from "@contexts/PaliWallet/V2Provider";
 import { captureException } from "@sentry/nextjs";
 import { useConstants } from "@contexts/useConstants";
-import { isPaliV2UtxoMode } from "@contexts/PaliWallet/network-query-policy";
+import {
+  isPaliEvmReady,
+  isPaliV2UtxoMode,
+} from "@contexts/PaliWallet/network-query-policy";
 
 interface INEVMContext {
   account?: string;
@@ -55,8 +58,15 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     if (!isEthereumAvailable) {
       return false;
     }
+    if (paliWallet.version === "v2" && paliWallet.isLoading) {
+      return false;
+    }
     if (paliWallet.version === "v2" && paliWallet.isEVMInjected) {
-      return !isPaliOnUtxo;
+      return isPaliEvmReady(
+        paliWallet.isEVMInjected,
+        paliWallet.isLoading,
+        paliWallet.isBitcoinBased
+      );
     }
     return metamask.isEnabled;
   }, [
@@ -64,7 +74,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     paliWallet.version,
     paliWallet.isEVMInjected,
     paliWallet.isBitcoinBased,
-    isPaliOnUtxo,
+    paliWallet.isLoading,
     isEthereumAvailable,
   ]);
   const web3 = useMemo(() => {

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -160,8 +160,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
   const normalizedChainId =
     typeof chainId.data === "string" ? chainId.data.toLowerCase() : undefined;
   const normalizedExpectedChainId = expectedChainId.toLowerCase();
-  const isExpectedChain =
-    isEnabled && normalizedChainId === normalizedExpectedChainId;
+  const isExpectedChain = normalizedChainId === normalizedExpectedChainId;
   const isWrongChain = Boolean(
     isEnabled &&
       normalizedChainId &&

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -126,7 +126,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
         throw error; // Re-throw the original error for other errors
       }
     },
-    enabled: Boolean(web3) && isEnabled  && !paliWallet.isBitcoinBased,
+    enabled: Boolean(web3) && isEnabled && !isPaliOnUtxo,
     retry: false, // Don't retry user interaction methods
     refetchOnWindowFocus: false, // Don't refetch on focus
   });

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -497,7 +497,12 @@ export const PaliWalletV2Provider: React.FC<{
     // Also listen for standard ethereum accountsChanged if in EVM mode
     let ethCleanup: (() => void) | undefined;
     
-    if (window.ethereum && isEVMInjected && !isBitcoinBased.data) {
+    if (
+      window.ethereum &&
+      isEVMInjected.data &&
+      isBitcoinBased.isFetched &&
+      !isBitcoinBased.data
+    ) {
       const handleEthAccountsChanged = () => {
         // handleAccountsChanged will handle invalidating NEVM queries
         handleAccountsChanged();
@@ -521,7 +526,13 @@ export const PaliWalletV2Provider: React.FC<{
         ethCleanup();
       }
     };
-  }, [isInstalled, isEVMInjected.data, isBitcoinBased.data, queryClient]); // Dependencies needed for proper cleanup/setup
+  }, [
+    isInstalled,
+    isEVMInjected.data,
+    isBitcoinBased.data,
+    isBitcoinBased.isFetched,
+    queryClient,
+  ]); // Dependencies needed for proper cleanup/setup
 
   const value: IPaliWalletV2Context = useMemo(
     () => ({

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -11,6 +11,10 @@ import { PaliWallet } from "./types";
 import MetamaskProvider from "@contexts/Metamask/Provider";
 import { isValidSYSAddress } from "@sidhujag/sysweb3-utils";
 import { useConstants } from "@contexts/useConstants";
+import {
+  PaliWalletNetworkType,
+  shouldRefreshNevmQueries,
+} from "./network-query-policy";
 
 export interface ProviderState {
   xpub: string;
@@ -57,8 +61,6 @@ interface Provider {
   isBitcoinBased: () => boolean;
 }
 
-type PaliWalletNetworkType = "bitcoin" | "ethereum";
-
 export interface IPaliWalletV2Context extends IPaliWalletContext {
   chainType: string | undefined;
   isBitcoinBased: boolean;
@@ -80,6 +82,7 @@ export const PaliWalletV2Provider: React.FC<{
   const queryClient = useQueryClient();
   const { constants } = useConstants();
   const isProcessingAccountChange = useRef(false);
+  const networkSwitchTarget = useRef<PaliWalletNetworkType | null>(null);
   
   const installed = useQuery(["pali", "is-installed"], {
     queryFn: () => {
@@ -293,7 +296,7 @@ export const PaliWalletV2Provider: React.FC<{
   );
 
   const switchTo = useCallback(
-    (networkType: PaliWalletNetworkType) => {
+    async (networkType: PaliWalletNetworkType) => {
       if (!isInstalled) {
         return Promise.reject("Pali Wallet is not installed");
       }
@@ -308,37 +311,43 @@ export const PaliWalletV2Provider: React.FC<{
         chainId = parseInt(constants?.chain_id ?? "0x39", 16);
       }
 
-      if (networkType === "bitcoin") {
-        return window.pali
-          .request({
+      networkSwitchTarget.current = networkType;
+
+      try {
+        if (networkType === "bitcoin") {
+          // Stop active wallet-backed EVM queries before Pali changes mode.
+          await queryClient.cancelQueries(["nevm"]);
+          await window.pali.request({
             method: "sys_changeUTXOEVM",
             params: [
               {
                 chainId,
               },
             ],
-          })
-          .then(() => {
-            isBitcoinBased.refetch().then(() => {
-              utxoAccount.refetch();
-              accountDetails.refetch();
-            });
           });
-      } else if (networkType === "ethereum") {
-        return window.ethereum
-          .request({
+          await isBitcoinBased.refetch();
+          await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
+          return;
+        }
+
+        if (networkType === "ethereum") {
+          await window.ethereum.request({
             method: "eth_changeUTXOEVM",
             params: [
               {
                 chainId,
               },
             ],
-          })
-          .then(() => {
-            isBitcoinBased.refetch();
           });
+          await isBitcoinBased.refetch();
+          await queryClient.invalidateQueries(["nevm"]);
+          return;
+        }
+
+        return Promise.reject("Invalid network type");
+      } finally {
+        networkSwitchTarget.current = null;
       }
-      return Promise.reject("Invalid network type");
     },
     [
       finalAccount,
@@ -362,6 +371,22 @@ export const PaliWalletV2Provider: React.FC<{
   useEffect(() => {
     if (!isInstalled || !window.pali) return;
 
+    const refreshQueriesForActiveNetwork = async () => {
+      if (networkSwitchTarget.current === "bitcoin") {
+        await queryClient.cancelQueries(["nevm"]);
+        await isBitcoinBased.refetch();
+        return;
+      }
+
+      const { data: bitcoinBased } = await isBitcoinBased.refetch();
+      if (shouldRefreshNevmQueries(bitcoinBased, networkSwitchTarget.current)) {
+        await queryClient.invalidateQueries(["nevm"]);
+        return;
+      }
+
+      await queryClient.cancelQueries(["nevm"]);
+    };
+
     // Handle any account changes (both UTXO and EVM)
     const handleAccountsChanged = () => {
       // Prevent recursive calls
@@ -374,10 +399,17 @@ export const PaliWalletV2Provider: React.FC<{
       // Check current network state without refetching
       const isCurrentlyBitcoinBased = isBitcoinBased.data;
       
-      if (isCurrentlyBitcoinBased) {
+      if (networkSwitchTarget.current === "bitcoin") {
+        void queryClient.cancelQueries(["nevm"]);
+      } else if (isCurrentlyBitcoinBased) {
         utxoAccount.refetch();
         accountDetails.refetch();
-      } else if (isCurrentlyBitcoinBased === false) {
+      } else if (
+        shouldRefreshNevmQueries(
+          isCurrentlyBitcoinBased,
+          networkSwitchTarget.current
+        )
+      ) {
         // Only invalidate NEVM queries when on EVM network
         queryClient.invalidateQueries(["nevm"]);
       }
@@ -401,15 +433,11 @@ export const PaliWalletV2Provider: React.FC<{
 
         // React to network-type and chain changes instantly
         if (data?.method === 'pali_isBitcoinBased') {
-          // Update UTXO/EVM mode
-          isBitcoinBased.refetch();
-          // NEVM-dependent queries may need invalidation
-          queryClient.invalidateQueries(["nevm"]);
+          void refreshQueriesForActiveNetwork();
         }
 
         if (data?.method === 'pali_chainChanged') {
-          // Invalidate NEVM queries (account/chain/gas/balances) on chain change
-          queryClient.invalidateQueries(["nevm"]);
+          void refreshQueriesForActiveNetwork();
         }
 
         if (data?.method === 'pali_unlockStateChanged') {
@@ -417,15 +445,14 @@ export const PaliWalletV2Provider: React.FC<{
           const unlocked = Boolean(data?.params?.isUnlocked ?? data?.params);
           if (unlocked) {
             // If on UTXO, refresh UTXO account/xpub; if on EVM, invalidate NEVM
-            if (isBitcoinBased.data) {
+            if (
+              isBitcoinBased.data &&
+              networkSwitchTarget.current !== "ethereum"
+            ) {
               utxoAccount.refetch();
               accountDetails.refetch();
-            } else if (isBitcoinBased.data === false) {
-              queryClient.invalidateQueries(["nevm"]);
             } else {
-              // Unknown state: refresh both light-weight queries
-              isBitcoinBased.refetch();
-              queryClient.invalidateQueries(["nevm"]);
+              void refreshQueriesForActiveNetwork();
             }
           }
         }

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -12,8 +12,8 @@ import MetamaskProvider from "@contexts/Metamask/Provider";
 import { isValidSYSAddress } from "@sidhujag/sysweb3-utils";
 import { useConstants } from "@contexts/useConstants";
 import {
+  getPaliNevmQueryAction,
   PaliWalletNetworkType,
-  shouldRefreshNevmQueries,
 } from "./network-query-policy";
 
 export interface ProviderState {
@@ -316,7 +316,15 @@ export const PaliWalletV2Provider: React.FC<{
       try {
         if (networkType === "bitcoin") {
           // Stop active wallet-backed EVM queries before Pali changes mode.
-          await queryClient.cancelQueries(["nevm"]);
+          if (
+            getPaliNevmQueryAction(
+              isEVMInjected.data,
+              isBitcoinBased.data,
+              networkType
+            ) === "cancel"
+          ) {
+            await queryClient.cancelQueries(["nevm"]);
+          }
           await window.pali.request({
             method: "sys_changeUTXOEVM",
             params: [
@@ -339,8 +347,16 @@ export const PaliWalletV2Provider: React.FC<{
               },
             ],
           });
-          await isBitcoinBased.refetch();
-          await queryClient.invalidateQueries(["nevm"]);
+          const { data: bitcoinBased } = await isBitcoinBased.refetch();
+          if (
+            getPaliNevmQueryAction(
+              isEVMInjected.data,
+              bitcoinBased,
+              networkType
+            ) === "refresh"
+          ) {
+            await queryClient.invalidateQueries(["nevm"]);
+          }
           return;
         }
 
@@ -354,6 +370,7 @@ export const PaliWalletV2Provider: React.FC<{
       isBitcoinBased,
       isInstalled,
       queryClient,
+      isEVMInjected.data,
       constants?.chain_id,
       constants?.isTestnet,
     ]
@@ -372,19 +389,29 @@ export const PaliWalletV2Provider: React.FC<{
     if (!isInstalled || !window.pali) return;
 
     const refreshQueriesForActiveNetwork = async () => {
-      if (networkSwitchTarget.current === "bitcoin") {
+      const currentAction = getPaliNevmQueryAction(
+        isEVMInjected.data,
+        isBitcoinBased.data,
+        networkSwitchTarget.current
+      );
+      if (currentAction === "cancel") {
         await queryClient.cancelQueries(["nevm"]);
-        await isBitcoinBased.refetch();
-        return;
       }
 
       const { data: bitcoinBased } = await isBitcoinBased.refetch();
-      if (shouldRefreshNevmQueries(bitcoinBased, networkSwitchTarget.current)) {
+      const nextAction = getPaliNevmQueryAction(
+        isEVMInjected.data,
+        bitcoinBased,
+        networkSwitchTarget.current
+      );
+      if (nextAction === "refresh") {
         await queryClient.invalidateQueries(["nevm"]);
         return;
       }
 
-      await queryClient.cancelQueries(["nevm"]);
+      if (nextAction === "cancel" && currentAction !== "cancel") {
+        await queryClient.cancelQueries(["nevm"]);
+      }
     };
 
     // Handle any account changes (both UTXO and EVM)
@@ -398,18 +425,22 @@ export const PaliWalletV2Provider: React.FC<{
       
       // Check current network state without refetching
       const isCurrentlyBitcoinBased = isBitcoinBased.data;
-      
-      if (networkSwitchTarget.current === "bitcoin") {
+      const nevmQueryAction = getPaliNevmQueryAction(
+        isEVMInjected.data,
+        isCurrentlyBitcoinBased,
+        networkSwitchTarget.current
+      );
+
+      if (nevmQueryAction === "cancel") {
         void queryClient.cancelQueries(["nevm"]);
-      } else if (isCurrentlyBitcoinBased) {
+      }
+      if (
+        isCurrentlyBitcoinBased &&
+        networkSwitchTarget.current !== "ethereum"
+      ) {
         utxoAccount.refetch();
         accountDetails.refetch();
-      } else if (
-        shouldRefreshNevmQueries(
-          isCurrentlyBitcoinBased,
-          networkSwitchTarget.current
-        )
-      ) {
+      } else if (nevmQueryAction === "refresh") {
         // Only invalidate NEVM queries when on EVM network
         queryClient.invalidateQueries(["nevm"]);
       }

--- a/contexts/PaliWallet/network-query-policy.test.ts
+++ b/contexts/PaliWallet/network-query-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  getPaliNevmQueryAction,
   isPaliV2UtxoMode,
-  shouldRefreshNevmQueries,
 } from "./network-query-policy";
 
 describe("Pali network query policy", () => {
@@ -12,12 +12,17 @@ describe("Pali network query policy", () => {
   });
 
   it("does not refresh EVM queries while switching to UTXO", () => {
-    expect(shouldRefreshNevmQueries(false, "bitcoin")).toBe(false);
+    expect(getPaliNevmQueryAction(true, false, "bitcoin")).toBe("cancel");
   });
 
   it("refreshes EVM queries only when EVM is active", () => {
-    expect(shouldRefreshNevmQueries(false, null)).toBe(true);
-    expect(shouldRefreshNevmQueries(true, null)).toBe(false);
-    expect(shouldRefreshNevmQueries(undefined, null)).toBe(false);
+    expect(getPaliNevmQueryAction(true, false, null)).toBe("refresh");
+    expect(getPaliNevmQueryAction(true, true, null)).toBe("cancel");
+    expect(getPaliNevmQueryAction(true, undefined, null)).toBe("none");
+  });
+
+  it("leaves MetaMask queries alone when Pali is not the EVM provider", () => {
+    expect(getPaliNevmQueryAction(false, false, "bitcoin")).toBe("none");
+    expect(getPaliNevmQueryAction(false, false, null)).toBe("none");
   });
 });

--- a/contexts/PaliWallet/network-query-policy.test.ts
+++ b/contexts/PaliWallet/network-query-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   getPaliNevmQueryAction,
+  isPaliEvmReady,
   isPaliV2UtxoMode,
 } from "./network-query-policy";
 
@@ -9,6 +10,13 @@ describe("Pali network query policy", () => {
     expect(isPaliV2UtxoMode("v2", true, true)).toBe(true);
     expect(isPaliV2UtxoMode("v2", true, false)).toBe(false);
     expect(isPaliV2UtxoMode("v1", undefined, true)).toBe(false);
+  });
+
+  it("waits for a confirmed EVM mode before enabling injected queries", () => {
+    expect(isPaliEvmReady(true, true, false)).toBe(false);
+    expect(isPaliEvmReady(true, false, undefined)).toBe(false);
+    expect(isPaliEvmReady(true, false, true)).toBe(false);
+    expect(isPaliEvmReady(true, false, false)).toBe(true);
   });
 
   it("does not refresh EVM queries while switching to UTXO", () => {

--- a/contexts/PaliWallet/network-query-policy.test.ts
+++ b/contexts/PaliWallet/network-query-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  isPaliV2UtxoMode,
+  shouldRefreshNevmQueries,
+} from "./network-query-policy";
+
+describe("Pali network query policy", () => {
+  it("disables the injected EVM provider when Pali v2 is on UTXO", () => {
+    expect(isPaliV2UtxoMode("v2", true, true)).toBe(true);
+    expect(isPaliV2UtxoMode("v2", true, false)).toBe(false);
+    expect(isPaliV2UtxoMode("v1", undefined, true)).toBe(false);
+  });
+
+  it("does not refresh EVM queries while switching to UTXO", () => {
+    expect(shouldRefreshNevmQueries(false, "bitcoin")).toBe(false);
+  });
+
+  it("refreshes EVM queries only when EVM is active", () => {
+    expect(shouldRefreshNevmQueries(false, null)).toBe(true);
+    expect(shouldRefreshNevmQueries(true, null)).toBe(false);
+    expect(shouldRefreshNevmQueries(undefined, null)).toBe(false);
+  });
+});

--- a/contexts/PaliWallet/network-query-policy.ts
+++ b/contexts/PaliWallet/network-query-policy.ts
@@ -1,5 +1,6 @@
 export type PaliWalletVersion = "v1" | "v2";
 export type PaliWalletNetworkType = "bitcoin" | "ethereum";
+export type NevmQueryAction = "cancel" | "refresh" | "none";
 
 export const isPaliV2UtxoMode = (
   version: PaliWalletVersion,
@@ -7,7 +8,16 @@ export const isPaliV2UtxoMode = (
   isBitcoinBased: boolean | undefined
 ) => version === "v2" && Boolean(isEVMInjected) && Boolean(isBitcoinBased);
 
-export const shouldRefreshNevmQueries = (
+export const getPaliNevmQueryAction = (
+  isEVMInjected: boolean | undefined,
   isBitcoinBased: boolean | undefined,
   networkSwitchTarget: PaliWalletNetworkType | null
-) => networkSwitchTarget !== "bitcoin" && isBitcoinBased === false;
+): NevmQueryAction => {
+  if (!isEVMInjected) {
+    return "none";
+  }
+  if (networkSwitchTarget === "bitcoin" || isBitcoinBased === true) {
+    return "cancel";
+  }
+  return isBitcoinBased === false ? "refresh" : "none";
+};

--- a/contexts/PaliWallet/network-query-policy.ts
+++ b/contexts/PaliWallet/network-query-policy.ts
@@ -8,6 +8,12 @@ export const isPaliV2UtxoMode = (
   isBitcoinBased: boolean | undefined
 ) => version === "v2" && Boolean(isEVMInjected) && Boolean(isBitcoinBased);
 
+export const isPaliEvmReady = (
+  isEVMInjected: boolean | undefined,
+  isLoading: boolean,
+  isBitcoinBased: boolean | undefined
+) => Boolean(isEVMInjected) && !isLoading && isBitcoinBased === false;
+
 export const getPaliNevmQueryAction = (
   isEVMInjected: boolean | undefined,
   isBitcoinBased: boolean | undefined,

--- a/contexts/PaliWallet/network-query-policy.ts
+++ b/contexts/PaliWallet/network-query-policy.ts
@@ -1,0 +1,13 @@
+export type PaliWalletVersion = "v1" | "v2";
+export type PaliWalletNetworkType = "bitcoin" | "ethereum";
+
+export const isPaliV2UtxoMode = (
+  version: PaliWalletVersion,
+  isEVMInjected: boolean | undefined,
+  isBitcoinBased: boolean | undefined
+) => version === "v2" && Boolean(isEVMInjected) && Boolean(isBitcoinBased);
+
+export const shouldRefreshNevmQueries = (
+  isBitcoinBased: boolean | undefined,
+  networkSwitchTarget: PaliWalletNetworkType | null
+) => networkSwitchTarget !== "bitcoin" && isBitcoinBased === false;

--- a/utils/balance-hooks.ts
+++ b/utils/balance-hooks.ts
@@ -1,6 +1,6 @@
 import { useConstants } from "@contexts/useConstants";
 import { isValidEthereumAddress } from "@sidhujag/sysweb3-utils";
-import { useWeb3 } from "components/Bridge/context/Web";
+import Web3 from "web3";
 
 import { useQuery } from "react-query";
 
@@ -66,13 +66,15 @@ export const useUtxoBalance = (
 };
 
 export const useNevmBalance = (address?: string) => {
-  const web3 = useWeb3();
   const { constants } = useConstants();
   return useQuery(
-    ["nevm", "balance", address],
+    ["nevm-rpc", "balance", constants?.rpc.nevm, address],
     async () => {
       if (!address) return Promise.resolve(0);
 
+      // Balance display is read-only and must not wake or switch the injected
+      // wallet when Pali is operating in UTXO mode.
+      const web3 = new Web3(constants!.rpc.nevm);
       let balRpc = await web3.eth
         .getBalance(address)
         .then(parseInt)
@@ -96,7 +98,7 @@ export const useNevmBalance = (address?: string) => {
       return ethBalance;
     },
     {
-      enabled: Boolean(constants),
+      enabled: Boolean(constants?.rpc.nevm),
     }
   );
 };


### PR DESCRIPTION
## Summary

- cancel wallet-backed NEVM queries before switching Pali to UTXO
- make Pali network notifications refresh NEVM state only when EVM is active
- disable injected EVM account, balance, and chain queries while Pali is on UTXO
- read display-only NEVM balances through the configured HTTP RPC
- add regression tests for the network query policy

## Root cause

After Pali successfully switched to UTXO, the bridge invalidated all NEVM queries in response to Pali's network notifications. Active and cached queries then issued `eth_chainId` or `eth_getBalance` through Pali's injected provider, causing Pali to correctly prompt the user to switch back to EVM.

## Impact

Selecting or changing the UTXO account no longer causes an immediate EVM switch prompt. Deliberate transitions back to EVM still refresh the required wallet state.

## Validation

- `jest --runInBand`: 55 tests passed
- `tsc --noEmit`: passed
- `next lint`: passed with one pre-existing hook dependency warning
- `next build`: passed