### PR TITLE
Fix Pali UTXO switch races and preserve MetaMask EVM

### DIFF
--- a/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
+++ b/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
@@ -12,6 +12,10 @@ import { useNevmBalance, useUtxoBalance } from "utils/balance-hooks";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import { useConstants } from "@contexts/useConstants";
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
+import {
+  getSyscoinChainId,
+  resolveSyscoinIsTestnet,
+} from "utils/network-config";
 
 const ErrorMessage = ({ message }: { message: string }) => (
   <Box sx={{ display: "flex", mb: 2 }}>
@@ -72,7 +76,10 @@ export const ConnectValidateStartTransferButton: React.FC<{
   const isNevmWrongNetwork = Boolean(nevmAddress) && !isExpectedChain;
 
   const isUtxoValid =
-    isValidSYSAddress(utxoAddress, constants?.isTestnet ? 5700 : 57) &&
+    isValidSYSAddress(
+      utxoAddress,
+      getSyscoinChainId(resolveSyscoinIsTestnet(constants))
+    ) &&
     !isUtxoNotEnoughGas &&
     !isSysxNotEnoughBalance &&
     utxoAssetType !== undefined;

--- a/components/Bridge/UTXOStepWrapper.tsx
+++ b/components/Bridge/UTXOStepWrapper.tsx
@@ -5,6 +5,10 @@ import {
 import { useConstants } from "@contexts/useConstants";
 import { Button } from "@mui/material";
 import { isValidSYSAddress } from "@sidhujag/sysweb3-utils";
+import {
+  getSyscoinChainId,
+  resolveSyscoinIsTestnet,
+} from "utils/network-config";
 
 type UTXOStepWrapperProps = {
   children: React.ReactNode;
@@ -28,7 +32,12 @@ const UTXOStepWrapper: React.FC<UTXOStepWrapperProps> = ({ children }) => {
     return <Button onClick={connectWallet}>Connect Pali Wallet</Button>;
   }
 
-  if (!isValidSYSAddress(connectedAccount, constants?.isTestnet ? 5700 : 57)) {
+  if (
+    !isValidSYSAddress(
+      connectedAccount,
+      getSyscoinChainId(resolveSyscoinIsTestnet(constants))
+    )
+  ) {
     return (
       <>
         <Button variant="contained" onClick={changeAccount}>

--- a/components/Bridge/WalletSwitch/UTXOConnect.tsx
+++ b/components/Bridge/WalletSwitch/UTXOConnect.tsx
@@ -15,6 +15,7 @@ import WalletSwitchCard from "./Card";
 import WalletSwitchConfirmCard from "./ConfirmCard";
 import { MIN_GAS_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
+import { switchToSyscoinThenChangeAccount } from "@contexts/PaliWallet/utxo-network";
 
 export type AssetType = "sys" | "sysx" | "none";
 
@@ -187,9 +188,12 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     setUtxo({ xpub: xpubAddress, address: connectedAccount });
   };
 
-  const change = () => {
-    !isBitcoinBased ? switchTo("bitcoin") : changeAccount();
-  };
+  const change = () =>
+    switchToSyscoinThenChangeAccount(
+      isBitcoinBased,
+      switchTo,
+      changeAccount
+    );
 
   const hasUtxoAddress = Boolean(transfer.utxoAddress);
 

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -9,7 +9,7 @@ import { IPaliWalletV2Context } from "@contexts/PaliWallet/V2Provider";
 import { captureException } from "@sentry/nextjs";
 import { useConstants } from "@contexts/useConstants";
 import {
-  isPaliEvmReady,
+  isNevmQueryReady,
   isPaliV2UtxoMode,
 } from "@contexts/PaliWallet/network-query-policy";
 
@@ -54,29 +54,27 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     paliWallet.isEVMInjected,
     paliWallet.isBitcoinBased
   );
-  const isEnabled = useMemo(() => {
-    if (!isEthereumAvailable) {
-      return false;
-    }
-    if (paliWallet.version === "v2" && paliWallet.isLoading) {
-      return false;
-    }
-    if (paliWallet.version === "v2" && paliWallet.isEVMInjected) {
-      return isPaliEvmReady(
+  const isEnabled = useMemo(
+    () =>
+      isNevmQueryReady(
+        isEthereumAvailable,
+        paliWallet.version === "v2",
         paliWallet.isEVMInjected,
         paliWallet.isLoading,
-        paliWallet.isBitcoinBased
-      );
-    }
-    return metamask.isEnabled;
-  }, [
-    metamask.isEnabled,
-    paliWallet.version,
-    paliWallet.isEVMInjected,
-    paliWallet.isBitcoinBased,
-    paliWallet.isLoading,
-    isEthereumAvailable,
-  ]);
+        paliWallet.isBitcoinBased,
+        paliWallet.isSwitchingToUtxo,
+        metamask.isEnabled
+      ),
+    [
+      isEthereumAvailable,
+      metamask.isEnabled,
+      paliWallet.version,
+      paliWallet.isEVMInjected,
+      paliWallet.isBitcoinBased,
+      paliWallet.isLoading,
+      paliWallet.isSwitchingToUtxo,
+    ]
+  );
   const web3 = useMemo(() => {
     if (!isEnabled) {
       return null;
@@ -97,7 +95,10 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     queryFn: async () => {
       try {
         // Double-check we're on EVM network before requesting accounts
-        if (paliWallet.isBitcoinBased) {
+        if (
+          isPaliEvmProvider &&
+          (paliWallet.isBitcoinBased || paliWallet.isSwitchingToUtxo)
+        ) {
           return null; // Don't request ETH accounts when on UTXO
         }
         

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -9,6 +9,7 @@ import { IPaliWalletV2Context } from "@contexts/PaliWallet/V2Provider";
 import { captureException } from "@sentry/nextjs";
 import { useConstants } from "@contexts/useConstants";
 import {
+  getNevmAccountRequestMethod,
   isNevmQueryReady,
   isPaliV2UtxoMode,
 } from "@contexts/PaliWallet/network-query-policy";
@@ -104,7 +105,9 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
         
         const result: (string | { success: false })[] =
           await window.ethereum.request({
-            method: "eth_requestAccounts",
+            // Account discovery runs automatically, so it must never open a
+            // wallet prompt. The interactive method is reserved for connect().
+            method: getNevmAccountRequestMethod("discover"),
           });
         if (
           result.length > 0 &&
@@ -218,16 +221,26 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
   };
 
   const connect = () => {
-    let prePromise = account.isFetched
+    const prePromise = account.data
       ? window.ethereum.request({
           method: "wallet_revokePermissions",
           params: [{ eth_accounts: {} }],
         })
       : Promise.resolve();
 
-    prePromise.then(() => {
-      return account.refetch();
-    });
+    void prePromise
+      .then(() =>
+        window.ethereum.request({
+          method: getNevmAccountRequestMethod("connect"),
+        })
+      )
+      .then(() => account.refetch())
+      .catch((error) => {
+        if (error?.code === 4001) {
+          return;
+        }
+        console.error("Failed to connect EVM account:", error);
+      });
   };
 
   const signMessage = (message: string): Promise<string> => {

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -323,18 +323,23 @@ export const PaliWalletV2Provider: React.FC<{
 
       try {
         if (networkType === "bitcoin") {
+          const { data: wasAlreadyOnUtxo } = await isBitcoinBased.refetch();
+
           // Stop active wallet-backed EVM queries before Pali changes mode.
           if (
             getPaliNevmQueryAction(
               isEVMInjected.data,
-              isBitcoinBased.data,
+              wasAlreadyOnUtxo,
               networkType
             ) === "cancel"
           ) {
             await queryClient.cancelQueries(["nevm"]);
           }
           await window.pali.request(
-            getPaliSyscoinSwitchRequest(Boolean(constants?.isTestnet))
+            getPaliSyscoinSwitchRequest(
+              Boolean(constants?.isTestnet),
+              Boolean(wasAlreadyOnUtxo)
+            )
           );
           await isBitcoinBased.refetch();
           await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -12,6 +12,10 @@ import MetamaskProvider from "@contexts/Metamask/Provider";
 import { isValidSYSAddress } from "@sidhujag/sysweb3-utils";
 import { useConstants } from "@contexts/useConstants";
 import {
+  getSyscoinChainId,
+  resolveSyscoinIsTestnet,
+} from "utils/network-config";
+import {
   getPaliNevmQueryAction,
   isPaliUtxoQueryReady,
   PaliWalletNetworkType,
@@ -86,7 +90,7 @@ export const PaliWalletV2Provider: React.FC<{
   children: React.ReactElement;
 }> = ({ children }) => {
   const queryClient = useQueryClient();
-  const { constants } = useConstants();
+  const { constants, refetch: refetchConstants } = useConstants();
   const isProcessingAccountChange = useRef(false);
   const networkSwitchTarget = useRef<PaliWalletNetworkType | null>(null);
   const [isSwitchingToUtxo, setIsSwitchingToUtxo] = useState(false);
@@ -110,6 +114,7 @@ export const PaliWalletV2Provider: React.FC<{
   });
 
   const isInstalled = installed.isFetched && installed.data;
+  const isBridgeTestnet = resolveSyscoinIsTestnet(constants);
 
   const isBitcoinBased = useQuery(["pali", "isBitcoinBased"], {
     queryFn: async () => {
@@ -233,11 +238,11 @@ export const PaliWalletV2Provider: React.FC<{
       finalAccount &&
       isValidSYSAddress(
         finalAccount.address,
-        constants?.isTestnet ? 5700 : 57
+        getSyscoinChainId(isBridgeTestnet)
       )
         ? finalAccount.address
         : undefined,
-    [finalAccount, constants?.isTestnet]
+    [finalAccount, isBridgeTestnet]
   );
 
   const xpubAddress = useMemo(
@@ -294,7 +299,7 @@ export const PaliWalletV2Provider: React.FC<{
         // Fallback to PSBT parsing (legacy format)
         const unserializedResp = syscoinUtils.importPsbtFromJson(
           response,
-          constants?.isTestnet
+          isBridgeTestnet
             ? syscoinUtils.syscoinNetworks.testnet
             : syscoinUtils.syscoinNetworks.mainnet
         );
@@ -307,7 +312,7 @@ export const PaliWalletV2Provider: React.FC<{
         };
       }
     },
-    [constants?.isTestnet]
+    [isBridgeTestnet]
   );
 
   const switchTo = useCallback(
@@ -322,6 +327,12 @@ export const PaliWalletV2Provider: React.FC<{
       }
 
       try {
+        const activeConstants = constants ?? (await refetchConstants()).data;
+        if (!activeConstants) {
+          return Promise.reject("Bridge network configuration is unavailable");
+        }
+        const activeIsTestnet = resolveSyscoinIsTestnet(activeConstants);
+
         if (networkType === "bitcoin") {
           const { data: wasAlreadyOnUtxo } = await isBitcoinBased.refetch();
 
@@ -337,7 +348,7 @@ export const PaliWalletV2Provider: React.FC<{
           }
           await window.pali.request(
             getPaliSyscoinSwitchRequest(
-              Boolean(constants?.isTestnet),
+              activeIsTestnet,
               Boolean(wasAlreadyOnUtxo)
             )
           );
@@ -347,12 +358,14 @@ export const PaliWalletV2Provider: React.FC<{
         }
 
         if (networkType === "ethereum") {
-          const chainId = parseInt(constants?.chain_id ?? "0x39", 16);
+          const chainId = Number(activeConstants.chain_id);
           await window.ethereum.request({
             method: "eth_changeUTXOEVM",
             params: [
               {
-                chainId,
+                chainId: Number.isFinite(chainId)
+                  ? chainId
+                  : getSyscoinChainId(activeIsTestnet),
               },
             ],
           });
@@ -383,8 +396,8 @@ export const PaliWalletV2Provider: React.FC<{
       isInstalled,
       queryClient,
       isEVMInjected.data,
-      constants?.chain_id,
-      constants?.isTestnet,
+      constants,
+      refetchConstants,
     ]
   );
 
@@ -540,7 +553,7 @@ export const PaliWalletV2Provider: React.FC<{
       isInstalled,
       sendTransaction,
       connectWallet,
-      isTestnet: Boolean(constants?.isTestnet),
+      isTestnet: isBridgeTestnet,
       balance,
       connectedAccount: sysAddress,
       xpubAddress,
@@ -570,7 +583,7 @@ export const PaliWalletV2Provider: React.FC<{
       isEVMInjected,
       isLoading,
       isSwitchingToUtxo,
-      constants?.isTestnet,
+      isBridgeTestnet,
       constants?.chain_id,
     ]
   );

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useMemo, useEffect, useRef } from "react";
+import { useCallback, useMemo, useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "react-query";
 import { UTXOTransaction } from "syscoinjs-lib";
 import PaliWalletContextProvider, {
@@ -13,8 +13,13 @@ import { isValidSYSAddress } from "@sidhujag/sysweb3-utils";
 import { useConstants } from "@contexts/useConstants";
 import {
   getPaliNevmQueryAction,
+  isPaliUtxoQueryReady,
   PaliWalletNetworkType,
 } from "./network-query-policy";
+import {
+  getPaliSyscoinSwitchRequest,
+  readPaliBitcoinBasedState,
+} from "./utxo-network";
 
 export interface ProviderState {
   xpub: string;
@@ -68,6 +73,7 @@ export interface IPaliWalletV2Context extends IPaliWalletContext {
   changeAccount: () => Promise<any>;
   isEVMInjected: boolean;
   isLoading: boolean;
+  isSwitchingToUtxo: boolean;
 }
 
 declare global {
@@ -83,6 +89,7 @@ export const PaliWalletV2Provider: React.FC<{
   const { constants } = useConstants();
   const isProcessingAccountChange = useRef(false);
   const networkSwitchTarget = useRef<PaliWalletNetworkType | null>(null);
+  const [isSwitchingToUtxo, setIsSwitchingToUtxo] = useState(false);
   
   const installed = useQuery(["pali", "is-installed"], {
     queryFn: () => {
@@ -105,10 +112,9 @@ export const PaliWalletV2Provider: React.FC<{
   const isInstalled = installed.isFetched && installed.data;
 
   const isBitcoinBased = useQuery(["pali", "isBitcoinBased"], {
-    queryFn: () => {
+    queryFn: async () => {
       if (typeof window === "undefined" || !window.pali) return false;
-      const bitcoinBased = window.pali.isBitcoinBased();
-      return Boolean(bitcoinBased);
+      return readPaliBitcoinBasedState(window.pali);
     },
     enabled: isInstalled && typeof window !== "undefined",
     refetchInterval: 1000,
@@ -186,7 +192,12 @@ export const PaliWalletV2Provider: React.FC<{
         return null; // Return null instead of throwing to prevent cascade for CORS errors
       }
     },
-    enabled: isInstalled && isBitcoinBased.isFetched,
+    enabled: isPaliUtxoQueryReady(
+      isInstalled,
+      isBitcoinBased.isFetched,
+      isBitcoinBased.data,
+      isSwitchingToUtxo
+    ),
     retry: false, // Don't retry user interaction methods
     refetchOnWindowFocus: false, // Don't refetch on focus
   });
@@ -199,7 +210,11 @@ export const PaliWalletV2Provider: React.FC<{
       });
       return account;
     },
-    enabled: Boolean(utxoAccount.data), // Only run after account is connected
+    enabled: Boolean(
+      utxoAccount.data &&
+        isBitcoinBased.data === true &&
+        !isSwitchingToUtxo
+    ),
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -301,17 +316,10 @@ export const PaliWalletV2Provider: React.FC<{
         return Promise.reject("Pali Wallet is not installed");
       }
 
-      // Get proper chainId based on network type and testnet status
-      let chainId: number;
-      if (networkType === "bitcoin") {
-        // Use UTXO network chainIds: 57 for mainnet, 5700 for testnet
-        chainId = constants?.isTestnet ? 5700 : 57;
-      } else {
-        // Use EVM chainId from constants
-        chainId = parseInt(constants?.chain_id ?? "0x39", 16);
-      }
-
       networkSwitchTarget.current = networkType;
+      if (networkType === "bitcoin") {
+        setIsSwitchingToUtxo(true);
+      }
 
       try {
         if (networkType === "bitcoin") {
@@ -325,20 +333,16 @@ export const PaliWalletV2Provider: React.FC<{
           ) {
             await queryClient.cancelQueries(["nevm"]);
           }
-          await window.pali.request({
-            method: "sys_changeUTXOEVM",
-            params: [
-              {
-                chainId,
-              },
-            ],
-          });
+          await window.pali.request(
+            getPaliSyscoinSwitchRequest(Boolean(constants?.isTestnet))
+          );
           await isBitcoinBased.refetch();
           await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
           return;
         }
 
         if (networkType === "ethereum") {
+          const chainId = parseInt(constants?.chain_id ?? "0x39", 16);
           await window.ethereum.request({
             method: "eth_changeUTXOEVM",
             params: [
@@ -362,6 +366,9 @@ export const PaliWalletV2Provider: React.FC<{
 
         return Promise.reject("Invalid network type");
       } finally {
+        if (networkType === "bitcoin") {
+          setIsSwitchingToUtxo(false);
+        }
         networkSwitchTarget.current = null;
       }
     },
@@ -406,16 +413,18 @@ export const PaliWalletV2Provider: React.FC<{
       );
       if (nextAction === "refresh") {
         await queryClient.invalidateQueries(["nevm"]);
-        return;
+        return bitcoinBased;
       }
 
       if (nextAction === "cancel" && currentAction !== "cancel") {
         await queryClient.cancelQueries(["nevm"]);
       }
+
+      return bitcoinBased;
     };
 
     // Handle any account changes (both UTXO and EVM)
-    const handleAccountsChanged = () => {
+    const handleAccountsChanged = async () => {
       // Prevent recursive calls
       if (isProcessingAccountChange.current) {
         return;
@@ -423,33 +432,20 @@ export const PaliWalletV2Provider: React.FC<{
       
       isProcessingAccountChange.current = true;
       
-      // Check current network state without refetching
-      const isCurrentlyBitcoinBased = isBitcoinBased.data;
-      const nevmQueryAction = getPaliNevmQueryAction(
-        isEVMInjected.data,
-        isCurrentlyBitcoinBased,
-        networkSwitchTarget.current
-      );
-
-      if (nevmQueryAction === "cancel") {
-        void queryClient.cancelQueries(["nevm"]);
+      try {
+        const bitcoinBased = await refreshQueriesForActiveNetwork();
+        if (
+          bitcoinBased &&
+          networkSwitchTarget.current !== "ethereum"
+        ) {
+          await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
+        }
+      } finally {
+        // Reset after a short delay to allow legitimate subsequent changes.
+        setTimeout(() => {
+          isProcessingAccountChange.current = false;
+        }, 100);
       }
-      if (
-        isCurrentlyBitcoinBased &&
-        networkSwitchTarget.current !== "ethereum"
-      ) {
-        utxoAccount.refetch();
-        accountDetails.refetch();
-      } else if (nevmQueryAction === "refresh") {
-        // Only invalidate NEVM queries when on EVM network
-        queryClient.invalidateQueries(["nevm"]);
-      }
-      // If isCurrentlyBitcoinBased is undefined, we don't know the state yet, so do nothing
-      
-      // Reset the flag after a short delay to allow for legitimate subsequent changes
-      setTimeout(() => {
-        isProcessingAccountChange.current = false;
-      }, 100);
     };
 
     // Listen for Pali notification events
@@ -459,7 +455,7 @@ export const PaliWalletV2Provider: React.FC<{
         const data = eventData.data || eventData;
         
         if (data?.method === 'pali_xpubChanged' || data?.method === 'pali_accountsChanged') {
-          handleAccountsChanged();
+          void handleAccountsChanged();
         }
 
         // React to network-type and chain changes instantly
@@ -505,7 +501,7 @@ export const PaliWalletV2Provider: React.FC<{
     ) {
       const handleEthAccountsChanged = () => {
         // handleAccountsChanged will handle invalidating NEVM queries
-        handleAccountsChanged();
+        void handleAccountsChanged();
       };
       
       window.ethereum.on("accountsChanged", handleEthAccountsChanged);
@@ -553,6 +549,7 @@ export const PaliWalletV2Provider: React.FC<{
       changeAccount,
       isEVMInjected: isEVMInjected.isFetched && Boolean(isEVMInjected.data),
       isLoading,
+      isSwitchingToUtxo,
     }),
     [
       isInstalled,
@@ -567,6 +564,7 @@ export const PaliWalletV2Provider: React.FC<{
       changeAccount,
       isEVMInjected,
       isLoading,
+      isSwitchingToUtxo,
       constants?.isTestnet,
       constants?.chain_id,
     ]

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -353,7 +353,6 @@ export const PaliWalletV2Provider: React.FC<{
             )
           );
           await isBitcoinBased.refetch();
-          await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
           return;
         }
 

--- a/contexts/PaliWallet/network-query-policy.test.ts
+++ b/contexts/PaliWallet/network-query-policy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   getPaliNevmQueryAction,
+  isNevmQueryReady,
   isPaliEvmReady,
+  isPaliUtxoQueryReady,
   isPaliV2UtxoMode,
 } from "./network-query-policy";
 
@@ -16,7 +18,28 @@ describe("Pali network query policy", () => {
     expect(isPaliEvmReady(true, true, false)).toBe(false);
     expect(isPaliEvmReady(true, false, undefined)).toBe(false);
     expect(isPaliEvmReady(true, false, true)).toBe(false);
+    expect(isPaliEvmReady(true, false, false, true)).toBe(false);
     expect(isPaliEvmReady(true, false, false)).toBe(true);
+  });
+
+  it("only enables automatic UTXO reads on confirmed UTXO mode", () => {
+    expect(isPaliUtxoQueryReady(true, true, true)).toBe(true);
+    expect(isPaliUtxoQueryReady(true, true, false)).toBe(false);
+    expect(isPaliUtxoQueryReady(true, false, true)).toBe(false);
+    expect(isPaliUtxoQueryReady(true, true, undefined)).toBe(false);
+    expect(isPaliUtxoQueryReady(true, true, true, true)).toBe(false);
+  });
+
+  it("keeps MetaMask active during Pali loading and UTXO switches", () => {
+    expect(
+      isNevmQueryReady(true, true, false, true, true, true, true)
+    ).toBe(true);
+  });
+
+  it("blocks injected Pali EVM queries throughout a UTXO switch", () => {
+    expect(
+      isNevmQueryReady(true, true, true, false, false, true, true)
+    ).toBe(false);
   });
 
   it("does not refresh EVM queries while switching to UTXO", () => {

--- a/contexts/PaliWallet/network-query-policy.test.ts
+++ b/contexts/PaliWallet/network-query-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  getNevmAccountRequestMethod,
   getPaliNevmQueryAction,
   isNevmQueryReady,
   isPaliEvmReady,
@@ -8,6 +9,13 @@ import {
 } from "./network-query-policy";
 
 describe("Pali network query policy", () => {
+  it("only opens the EVM account picker for an explicit connection", () => {
+    expect(getNevmAccountRequestMethod("discover")).toBe("eth_accounts");
+    expect(getNevmAccountRequestMethod("connect")).toBe(
+      "eth_requestAccounts"
+    );
+  });
+
   it("disables the injected EVM provider when Pali v2 is on UTXO", () => {
     expect(isPaliV2UtxoMode("v2", true, true)).toBe(true);
     expect(isPaliV2UtxoMode("v2", true, false)).toBe(false);

--- a/contexts/PaliWallet/network-query-policy.ts
+++ b/contexts/PaliWallet/network-query-policy.ts
@@ -11,8 +11,47 @@ export const isPaliV2UtxoMode = (
 export const isPaliEvmReady = (
   isEVMInjected: boolean | undefined,
   isLoading: boolean,
-  isBitcoinBased: boolean | undefined
-) => Boolean(isEVMInjected) && !isLoading && isBitcoinBased === false;
+  isBitcoinBased: boolean | undefined,
+  isSwitchingToUtxo = false
+) =>
+  Boolean(isEVMInjected) &&
+  !isLoading &&
+  !isSwitchingToUtxo &&
+  isBitcoinBased === false;
+
+export const isNevmQueryReady = (
+  isEthereumAvailable: boolean | undefined,
+  isPaliV2: boolean,
+  isPaliEvmInjected: boolean | undefined,
+  isPaliLoading: boolean,
+  isPaliBitcoinBased: boolean | undefined,
+  isSwitchingToUtxo: boolean,
+  isMetaMaskEnabled: boolean
+) => {
+  if (!isEthereumAvailable) {
+    return false;
+  }
+  if (isPaliV2 && isPaliEvmInjected) {
+    return isPaliEvmReady(
+      isPaliEvmInjected,
+      isPaliLoading,
+      isPaliBitcoinBased,
+      isSwitchingToUtxo
+    );
+  }
+  return isMetaMaskEnabled;
+};
+
+export const isPaliUtxoQueryReady = (
+  isInstalled: boolean | undefined,
+  isModeFetched: boolean,
+  isBitcoinBased: boolean | undefined,
+  isSwitchingToUtxo = false
+) =>
+  Boolean(isInstalled) &&
+  isModeFetched &&
+  isBitcoinBased === true &&
+  !isSwitchingToUtxo;
 
 export const getPaliNevmQueryAction = (
   isEVMInjected: boolean | undefined,

--- a/contexts/PaliWallet/network-query-policy.ts
+++ b/contexts/PaliWallet/network-query-policy.ts
@@ -1,6 +1,11 @@
 export type PaliWalletVersion = "v1" | "v2";
 export type PaliWalletNetworkType = "bitcoin" | "ethereum";
 export type NevmQueryAction = "cancel" | "refresh" | "none";
+export type NevmAccountRequestIntent = "discover" | "connect";
+
+export const getNevmAccountRequestMethod = (
+  intent: NevmAccountRequestIntent
+) => (intent === "connect" ? "eth_requestAccounts" : "eth_accounts");
 
 export const isPaliV2UtxoMode = (
   version: PaliWalletVersion,

--- a/contexts/PaliWallet/utxo-network.test.ts
+++ b/contexts/PaliWallet/utxo-network.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  getPaliSyscoinSwitchRequest,
+  readPaliBitcoinBasedState,
+  switchToSyscoinThenChangeAccount,
+} from "./utxo-network";
+
+describe("Pali Syscoin UTXO network handling", () => {
+  it("uses the UTXO chain-switch method for Syscoin mainnet", () => {
+    expect(getPaliSyscoinSwitchRequest(false)).toEqual({
+      method: "sys_switchChain",
+      params: [{ chainId: 57 }],
+    });
+  });
+
+  it("uses the Syscoin testnet UTXO chain id", () => {
+    expect(getPaliSyscoinSwitchRequest(true)).toEqual({
+      method: "sys_switchChain",
+      params: [{ chainId: 5700 }],
+    });
+  });
+
+  it("reads the authoritative background mode instead of stale in-page state", async () => {
+    const provider = {
+      request: jest.fn(async () => ({ isBitcoinBased: true })),
+      isBitcoinBased: jest.fn(() => false),
+    };
+
+    await expect(readPaliBitcoinBasedState(provider)).resolves.toBe(true);
+    expect(provider.isBitcoinBased).not.toHaveBeenCalled();
+  });
+
+  it("falls back to in-page mode for older Pali v2 builds", async () => {
+    const provider = {
+      request: jest.fn(async () => {
+        throw new Error("Unsupported method");
+      }),
+      isBitcoinBased: jest.fn(() => true),
+    };
+
+    await expect(readPaliBitcoinBasedState(provider)).resolves.toBe(true);
+  });
+
+  it("ensures Syscoin is active before opening the account picker", async () => {
+    const calls: string[] = [];
+    const switchTo = jest.fn(async (networkType: "bitcoin" | "ethereum") => {
+      calls.push(`switch:${networkType}`);
+    });
+    const changeAccount = jest.fn(async () => {
+      calls.push("change-account");
+    });
+
+    await switchToSyscoinThenChangeAccount(true, switchTo, changeAccount);
+
+    expect(calls).toEqual(["switch:bitcoin", "change-account"]);
+  });
+
+  it("uses the account selected during an EVM-to-UTXO reconnect", async () => {
+    const switchTo = jest.fn(async () => undefined);
+    const changeAccount = jest.fn(async () => undefined);
+
+    await switchToSyscoinThenChangeAccount(false, switchTo, changeAccount);
+
+    expect(switchTo).toHaveBeenCalledWith("bitcoin");
+    expect(changeAccount).not.toHaveBeenCalled();
+  });
+
+  it("does not open the account picker when the network switch is rejected", async () => {
+    const switchError = new Error("Network switch rejected");
+    const switchTo = jest.fn(async () => {
+      throw switchError;
+    });
+    const changeAccount = jest.fn(async () => undefined);
+
+    await expect(
+      switchToSyscoinThenChangeAccount(true, switchTo, changeAccount)
+    ).rejects.toBe(switchError);
+    expect(changeAccount).not.toHaveBeenCalled();
+  });
+});

--- a/contexts/PaliWallet/utxo-network.test.ts
+++ b/contexts/PaliWallet/utxo-network.test.ts
@@ -7,16 +7,23 @@ import {
 
 describe("Pali Syscoin UTXO network handling", () => {
   it("uses the UTXO chain-switch method for Syscoin mainnet", () => {
-    expect(getPaliSyscoinSwitchRequest(false)).toEqual({
+    expect(getPaliSyscoinSwitchRequest(false, true)).toEqual({
       method: "sys_switchChain",
       params: [{ chainId: 57 }],
     });
   });
 
   it("uses the Syscoin testnet UTXO chain id", () => {
-    expect(getPaliSyscoinSwitchRequest(true)).toEqual({
+    expect(getPaliSyscoinSwitchRequest(true, true)).toEqual({
       method: "sys_switchChain",
       params: [{ chainId: 5700 }],
+    });
+  });
+
+  it("switches from the EVM family before selecting a UTXO account", () => {
+    expect(getPaliSyscoinSwitchRequest(false, false)).toEqual({
+      method: "sys_changeUTXOEVM",
+      params: [{ chainId: 57 }],
     });
   });
 

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -1,4 +1,5 @@
 import type { PaliWalletNetworkType } from "./network-query-policy";
+import { getSyscoinChainId } from "utils/network-config";
 
 type PaliProvider = {
   isBitcoinBased: () => boolean;
@@ -21,7 +22,7 @@ export const getPaliSyscoinSwitchRequest = (
   method: isAlreadyOnUtxo ? "sys_switchChain" : "sys_changeUTXOEVM",
   params: [
     {
-      chainId: isTestnet ? 5700 : 57,
+      chainId: getSyscoinChainId(isTestnet),
     },
   ],
 });

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -14,8 +14,11 @@ type PaliNetworkSwitch = (
 
 type PaliAccountChange = () => Promise<unknown>;
 
-export const getPaliSyscoinSwitchRequest = (isTestnet: boolean) => ({
-  method: "sys_switchChain",
+export const getPaliSyscoinSwitchRequest = (
+  isTestnet: boolean,
+  isAlreadyOnUtxo: boolean
+) => ({
+  method: isAlreadyOnUtxo ? "sys_switchChain" : "sys_changeUTXOEVM",
   params: [
     {
       chainId: isTestnet ? 5700 : 57,

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -1,0 +1,51 @@
+import type { PaliWalletNetworkType } from "./network-query-policy";
+
+type PaliProvider = {
+  isBitcoinBased: () => boolean;
+  request: (args: {
+    method: string;
+    params?: unknown[] | Record<string, unknown>;
+  }) => Promise<unknown>;
+};
+
+type PaliNetworkSwitch = (
+  networkType: PaliWalletNetworkType
+) => Promise<void>;
+
+type PaliAccountChange = () => Promise<unknown>;
+
+export const getPaliSyscoinSwitchRequest = (isTestnet: boolean) => ({
+  method: "sys_switchChain",
+  params: [
+    {
+      chainId: isTestnet ? 5700 : 57,
+    },
+  ],
+});
+
+export const readPaliBitcoinBasedState = async (provider: PaliProvider) => {
+  try {
+    const state = (await provider.request({
+      method: "wallet_getSysProviderState",
+    })) as { isBitcoinBased?: unknown } | null;
+
+    if (typeof state?.isBitcoinBased === "boolean") {
+      return state.isBitcoinBased;
+    }
+  } catch {
+    // Older Pali v2 builds can fall back to the in-page provider state.
+  }
+
+  return Boolean(provider.isBitcoinBased());
+};
+
+export const switchToSyscoinThenChangeAccount = async (
+  wasAlreadyOnUtxo: boolean,
+  switchTo: PaliNetworkSwitch,
+  changeAccount: PaliAccountChange
+) => {
+  await switchTo("bitcoin");
+  if (wasAlreadyOnUtxo) {
+    return changeAccount();
+  }
+};

--- a/contexts/useConstants.ts
+++ b/contexts/useConstants.ts
@@ -1,7 +1,12 @@
 import { useQuery } from "react-query";
 import { buildApiUrl } from "utils/api-base-url";
+import {
+  getSyscoinChainId,
+  isSyscoinTestnetHost,
+  resolveSyscoinIsTestnet,
+} from "utils/network-config";
 
-type Constants = {
+export type Constants = {
   contracts: {
     relayContract: { address: string };
     ecr20ManagerContract: { address: string };
@@ -25,8 +30,31 @@ type Constants = {
 export const useConstants = () => {
   const query = useQuery<Constants>({
     queryKey: "constants",
-    queryFn: () => {
-      return fetch(buildApiUrl("/api/constants")).then((res) => res.json());
+    queryFn: async () => {
+      const response = await fetch(buildApiUrl("/api/constants"));
+      if (!response.ok) {
+        throw new Error("Unable to load bridge network configuration");
+      }
+
+      const constants = (await response.json()) as Constants;
+      const configuredChainId =
+        constants.chain_id || process.env.NEXT_PUBLIC_CHAIN_ID;
+      const isTestnet = resolveSyscoinIsTestnet({
+        chain_id: configuredChainId,
+        isTestnet:
+          constants.isTestnet ||
+          process.env.NEXT_PUBLIC_IS_TESTNET === "true" ||
+          (typeof window !== "undefined" &&
+            isSyscoinTestnetHost(window.location.hostname)),
+      });
+      const chainId =
+        configuredChainId || `0x${getSyscoinChainId(isTestnet).toString(16)}`;
+
+      return {
+        ...constants,
+        chain_id: chainId,
+        isTestnet,
+      };
     },
   });
 

--- a/pages/api/constants.ts
+++ b/pages/api/constants.ts
@@ -1,5 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { applyApiCors } from "utils/api/cors";
+import {
+  isSyscoinTestnetHost,
+  resolveSyscoinIsTestnet,
+} from "utils/network-config";
 import { resolveUtxoBlockbookUrl } from "utils/syscoin-urls";
 
 function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -15,6 +19,17 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "GET") {
     return res.status(405).json({ message: "Method not allowed" });
   }
+
+  const chainId = process.env.CHAIN_ID || process.env.NEXT_PUBLIC_CHAIN_ID;
+  const configuredIsTestnet =
+    process.env.IS_TESTNET ?? process.env.NEXT_PUBLIC_IS_TESTNET;
+  const isTestnet = resolveSyscoinIsTestnet({
+    chain_id: chainId,
+    isTestnet:
+      configuredIsTestnet === "true" ||
+      (configuredIsTestnet === undefined &&
+        isSyscoinTestnetHost(req.headers.host)),
+  });
 
   return res.status(200).json({
     contracts: {
@@ -35,8 +50,8 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
       nevm: process.env.NEVM_API_URL || "",  // Only EVM networks use API URLs
       // No UTXO API URL - UTXO networks don't need separate API URLs
     },
-    isTestnet: process.env.IS_TESTNET === "true",
-    chain_id: process.env.CHAIN_ID,
+    isTestnet,
+    chain_id: chainId,
   });
 }
 

--- a/utils/network-config.test.ts
+++ b/utils/network-config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getSyscoinChainId,
+  isSyscoinTestnetHost,
+  resolveSyscoinIsTestnet,
+} from "./network-config";
+
+describe("Syscoin network configuration", () => {
+  it("treats the configured NEVM testnet chain as authoritative", () => {
+    expect(
+      resolveSyscoinIsTestnet({ isTestnet: false, chain_id: "0x1644" })
+    ).toBe(true);
+  });
+
+  it("does not treat the mainnet chain as testnet", () => {
+    expect(
+      resolveSyscoinIsTestnet({ isTestnet: true, chain_id: "0x39" })
+    ).toBe(false);
+  });
+
+  it("falls back to the explicit testnet flag without a known chain", () => {
+    expect(resolveSyscoinIsTestnet({ isTestnet: true })).toBe(true);
+  });
+
+  it("returns the matching Syscoin UTXO and NEVM chain id", () => {
+    expect(getSyscoinChainId(false)).toBe(57);
+    expect(getSyscoinChainId(true)).toBe(5700);
+  });
+
+  it("recognizes the Tanenbaum and Vercel testnet hosts", () => {
+    expect(isSyscoinTestnetHost("bridge.tanenbaum.io")).toBe(true);
+    expect(
+      isSyscoinTestnetHost(
+        "bridge-testnet-eavgyydou-sys-labs-1f6f97e5.vercel.app"
+      )
+    ).toBe(true);
+  });
+
+  it("does not treat the mainnet hosts as testnet", () => {
+    expect(isSyscoinTestnetHost("bridge.syscoin.org")).toBe(false);
+    expect(
+      isSyscoinTestnetHost(
+        "syscoin-bridge-git-main-sys-labs-1f6f97e5.vercel.app"
+      )
+    ).toBe(false);
+  });
+});

--- a/utils/network-config.ts
+++ b/utils/network-config.ts
@@ -1,0 +1,36 @@
+export type SyscoinNetworkConfig = {
+  isTestnet?: boolean;
+  chain_id?: string;
+};
+
+export const SYSCOIN_MAINNET_CHAIN_ID = 57;
+export const SYSCOIN_TESTNET_CHAIN_ID = 5700;
+
+export const resolveSyscoinIsTestnet = (
+  config?: SyscoinNetworkConfig | null
+) => {
+  const configuredChainId = Number(config?.chain_id);
+
+  if (configuredChainId === SYSCOIN_TESTNET_CHAIN_ID) {
+    return true;
+  }
+
+  if (configuredChainId === SYSCOIN_MAINNET_CHAIN_ID) {
+    return false;
+  }
+
+  return Boolean(config?.isTestnet);
+};
+
+export const getSyscoinChainId = (isTestnet: boolean) =>
+  isTestnet ? SYSCOIN_TESTNET_CHAIN_ID : SYSCOIN_MAINNET_CHAIN_ID;
+
+export const isSyscoinTestnetHost = (hostname?: string | null) => {
+  const normalizedHostname = hostname?.split(":")[0].toLowerCase();
+
+  return (
+    normalizedHostname === "bridge.tanenbaum.io" ||
+    (Boolean(normalizedHostname?.startsWith("bridge-testnet-")) &&
+      Boolean(normalizedHostname?.endsWith(".vercel.app")))
+  );
+};


### PR DESCRIPTION
## Summary

- prevent automatic Pali UTXO account requests while Pali is still on EVM
- keep injected Pali EVM queries disabled throughout the UTXO switch and reconnect flow
- read Pali mode from authoritative provider state after network changes
- use `sys_switchChain` for Bitcoin-to-Syscoin UTXO transitions
- preserve MetaMask as an independent EVM provider while Pali handles Syscoin UTXO
- add regression coverage for switching, rejection, stale provider state, and hybrid Pali/MetaMask usage

## Root cause

The bridge enabled its UTXO account query as soon as Pali mode was fetched, even when the fetched mode was EVM. That could issue `sys_requestAccounts` on Rollux, switch and reconnect Pali to Syscoin UTXO, then briefly re-enable wallet-backed `eth_*` queries from stale in-page mode state and prompt for EVM again.

The account-change path also treated Bitcoin and Syscoin as the same generic UTXO mode, so it opened Bitcoin accounts instead of first requesting the Syscoin UTXO chain.

## Impact

Rollux/EVM → Syscoin UTXO no longer bounces back to EVM after the HD-account reconnect. Bitcoin → Syscoin UTXO requests the correct chain before account selection. When MetaMask owns `window.ethereum`, it remains available for EVM while Pali independently handles the UTXO side.

## Validation

- `npm test -- --runInBand`: 67 tests passed
- `npm exec -- tsc --noEmit`: passed
- `npm run lint`: passed with one pre-existing hook dependency warning
- `npm run build`: passed