### PR TITLE
Proxy UTXO xpub balance requests

### DIFF
--- a/api/routes/__tests__/utxo-xpub-next-route.test.ts
+++ b/api/routes/__tests__/utxo-xpub-next-route.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { NextApiRequest, NextApiResponse } from "next";
+import handler from "../../../pages/api/utxo/xpub/[xpub]";
+
+type MockResponse = NextApiResponse & {
+  body?: unknown;
+  statusCode: number;
+};
+
+const createResponse = (): MockResponse => {
+  const headers = new Map<string, string | string[]>();
+  const response: {
+    body?: unknown;
+    statusCode: number;
+    [key: string]: unknown;
+  } = {
+    statusCode: 200,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    send(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    end() {
+      return this;
+    },
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name, value);
+      return this;
+    },
+    getHeader(name: string) {
+      return headers.get(name);
+    },
+  };
+
+  return response as unknown as MockResponse;
+};
+
+const createRequest = (details = "basic") =>
+  ({
+    method: "GET",
+    headers: {},
+    query: { xpub: "vpub-test", details },
+    socket: {},
+  } as unknown as NextApiRequest);
+
+const originalEnvironment = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnvironment };
+  jest.restoreAllMocks();
+});
+
+describe("UTXO xpub proxy", () => {
+  it("falls back to the configured UTXO RPC and proxies the response", async () => {
+    delete process.env.UTXO_EXPLORER;
+    process.env.UTXO_RPC_URL = "https://testnet-blockbook.example";
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      status: 200,
+      text: async () => '{"balance":"1"}',
+      headers: { get: () => "application/json" },
+    } as unknown as Response);
+    const response = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://testnet-blockbook.example/api/v2/xpub/vpub-test?details=basic",
+      { headers: { Accept: "application/json" } }
+    );
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('{"balance":"1"}');
+  });
+
+  it("only forwards supported detail modes", async () => {
+    process.env.UTXO_EXPLORER = "https://testnet-blockbook.example";
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      status: 200,
+      text: async () => "{}",
+      headers: { get: () => "application/json" },
+    } as unknown as Response);
+
+    await handler(createRequest("everything"), createResponse());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://testnet-blockbook.example/api/v2/xpub/vpub-test?details=basic",
+      { headers: { Accept: "application/json" } }
+    );
+  });
+
+  it("fails clearly when no Blockbook endpoint is configured", async () => {
+    delete process.env.UTXO_EXPLORER;
+    delete process.env.UTXO_RPC_URL;
+    delete process.env.NEXT_PUBLIC_BLOCKBOOK_API_URL;
+    const fetchMock = jest.spyOn(global, "fetch");
+    const response = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(503);
+    expect(response.body).toEqual({
+      message: "UTXO Blockbook is not configured",
+    });
+  });
+});

--- a/pages/api/constants.ts
+++ b/pages/api/constants.ts
@@ -4,7 +4,7 @@ import {
   isSyscoinTestnetHost,
   resolveSyscoinIsTestnet,
 } from "utils/network-config";
-import { resolveUtxoBlockbookUrl } from "utils/syscoin-urls";
+import { firstConfiguredUtxoBlockbookUrl } from "utils/syscoin-urls";
 
 function handler(req: NextApiRequest, res: NextApiResponse) {
   if (
@@ -40,11 +40,19 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
     },
     rpc: {
       nevm: process.env.NEVM_RPC_URL,
-      utxo: resolveUtxoBlockbookUrl(process.env.UTXO_RPC_URL),
+      utxo: firstConfiguredUtxoBlockbookUrl(
+        process.env.UTXO_RPC_URL,
+        process.env.UTXO_EXPLORER,
+        process.env.NEXT_PUBLIC_BLOCKBOOK_API_URL
+      ),
     },
     explorer: {
       nevm: process.env.NEVM_EXPLORER,
-      utxo: resolveUtxoBlockbookUrl(process.env.UTXO_EXPLORER),
+      utxo: firstConfiguredUtxoBlockbookUrl(
+        process.env.UTXO_EXPLORER,
+        process.env.UTXO_RPC_URL,
+        process.env.NEXT_PUBLIC_BLOCKBOOK_API_URL
+      ),
     },
     apiUrl: {
       nevm: process.env.NEVM_API_URL || "",  // Only EVM networks use API URLs

--- a/pages/api/utxo/xpub/[xpub].ts
+++ b/pages/api/utxo/xpub/[xpub].ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { applyApiCors } from "utils/api/cors";
+import { firstConfiguredUtxoBlockbookUrl } from "utils/syscoin-urls";
+
+const allowedDetails = new Set(["basic", "tokenBalances"]);
+
+const firstQueryValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (
+    applyApiCors(req, res, {
+      allowMethods: ["GET", "OPTIONS"],
+      allowWildcardOrigin: true,
+    })
+  ) {
+    return;
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const xpub = firstQueryValue(req.query.xpub);
+  if (!xpub) {
+    return res.status(400).json({ message: "Missing xpub" });
+  }
+
+  const requestedDetails = firstQueryValue(req.query.details);
+  const details =
+    requestedDetails && allowedDetails.has(requestedDetails)
+      ? requestedDetails
+      : "basic";
+  const blockbookUrl = firstConfiguredUtxoBlockbookUrl(
+    process.env.UTXO_EXPLORER,
+    process.env.UTXO_RPC_URL,
+    process.env.NEXT_PUBLIC_BLOCKBOOK_API_URL
+  );
+
+  if (!blockbookUrl) {
+    return res
+      .status(503)
+      .json({ message: "UTXO Blockbook is not configured" });
+  }
+
+  try {
+    const response = await fetch(
+      `${blockbookUrl}/api/v2/xpub/${encodeURIComponent(
+        xpub
+      )}?details=${details}`,
+      { headers: { Accept: "application/json" } }
+    );
+    const body = await response.text();
+    const contentType = response.headers.get("content-type");
+    if (contentType) {
+      res.setHeader("Content-Type", contentType);
+    }
+    return res.status(response.status).send(body);
+  } catch {
+    return res.status(502).json({ message: "UTXO Blockbook is unavailable" });
+  }
+};
+
+export default handler;

--- a/utils/balance-hooks.ts
+++ b/utils/balance-hooks.ts
@@ -3,6 +3,7 @@ import { isValidEthereumAddress } from "@sidhujag/sysweb3-utils";
 import Web3 from "web3";
 
 import { useQuery } from "react-query";
+import { buildApiUrl } from "./api-base-url";
 
 interface TokenAsset {
   assetGuid: string;
@@ -34,13 +35,16 @@ export const useUtxoBalance = (
     async () => {
       if (!xpub || isValidEthereumAddress(xpub)) return Promise.resolve(0);
       const details = assetGuid && address ? "tokenBalances" : "basic";
-      const url =
-        constants!.explorer.utxo +
-        "/api/v2/xpub/" +
-        xpub +
-        `?details=${details}`;
+      const url = buildApiUrl(
+        `/api/utxo/xpub/${encodeURIComponent(xpub)}?details=${details}`
+      );
       const balanceInText = await fetch(url)
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error("Unable to load UTXO balance");
+          }
+          return res.json();
+        })
         .then((res: BalanceResp) => {
           if (assetGuid && address) {
             if (!res.tokensAsset) {

--- a/utils/syscoin-urls.test.ts
+++ b/utils/syscoin-urls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  firstConfiguredUtxoBlockbookUrl,
   MAINNET_BLOCKBOOK_URL,
   resolveUtxoBlockbookUrl,
 } from "./syscoin-urls";
@@ -19,5 +20,24 @@ describe("resolveUtxoBlockbookUrl", () => {
     expect(resolveUtxoBlockbookUrl("https://custom-blockbook.example")).toBe(
       "https://custom-blockbook.example"
     );
+  });
+
+  it("uses the first configured Blockbook URL", () => {
+    expect(
+      firstConfiguredUtxoBlockbookUrl(
+        undefined,
+        "https://testnet-blockbook.example",
+        "https://fallback.example"
+      )
+    ).toBe("https://testnet-blockbook.example");
+  });
+
+  it("normalizes the selected legacy Blockbook URL", () => {
+    expect(
+      firstConfiguredUtxoBlockbookUrl(
+        undefined,
+        "https://blockbook.syscoin.org"
+      )
+    ).toBe(MAINNET_BLOCKBOOK_URL);
   });
 });

--- a/utils/syscoin-urls.ts
+++ b/utils/syscoin-urls.ts
@@ -9,3 +9,16 @@ export const resolveUtxoBlockbookUrl = (url?: string) => {
 
   return url;
 };
+
+export const firstConfiguredUtxoBlockbookUrl = (
+  ...urls: Array<string | undefined>
+) => {
+  for (const url of urls) {
+    const resolvedUrl = resolveUtxoBlockbookUrl(url);
+    if (resolvedUrl) {
+      return resolvedUrl;
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
- proxy UTXO xpub balance reads through a same-origin bridge API route
- fall back between UTXO explorer, RPC, and legacy public Blockbook configuration
- prevent malformed `/bridge/undefined/api/v2/xpub/...` requests and browser-side Blockbook CORS failures
- validate proxy detail modes and return explicit configuration/upstream errors

## Verification
- `npm test -- --runInBand` (80 tests)
- `npm run lint` (passes with one pre-existing hook warning)
- `npm run build`
- `git diff --check origin/main...HEAD`