### PR TITLE
Normalize NEVM chain IDs

### DIFF
--- a/components/Bridge/NEVMStepWrapepr.tsx
+++ b/components/Bridge/NEVMStepWrapepr.tsx
@@ -1,6 +1,6 @@
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
-import { Button } from "@mui/material";
+import { Alert, Button } from "@mui/material";
 import { isValidEthereumAddress } from "@sidhujag/sysweb3-utils";
 import { useTransfer } from "./context/TransferContext";
 import { useState } from "react";
@@ -13,11 +13,21 @@ const NEVMStepWrapper: React.FC<Props> = ({ children }) => {
   const { version, isBitcoinBased, switchTo, isEVMInjected } =
     usePaliWalletV2();
 
-  const { connect, account, isExpectedChain, switchToMainnet } = useNEVM();
+  const {
+    connect,
+    account,
+    expectedChainId,
+    isExpectedChain,
+    switchToMainnet,
+  } = useNEVM();
   const { transfer } = useTransfer();
   const nevmAccount = account ?? transfer.nevmAddress ?? "";
   const hasNevmAccount = nevmAccount !== "";
   const [hasSwitched, setHasSwitched] = useState(false);
+
+  if (!expectedChainId) {
+    return <Alert severity="error">NEVM network is not configured</Alert>;
+  }
 
   // Only show switch button if we haven't switched yet and Pali is in UTXO mode
   if (version === "v2" && isBitcoinBased && isEVMInjected && !hasSwitched) {

--- a/components/Bridge/WalletSwitch/NEVMConnect.tsx
+++ b/components/Bridge/WalletSwitch/NEVMConnect.tsx
@@ -18,7 +18,13 @@ type NEVMConnectProps = {
 const minAmount = MIN_GAS_AMOUNT;
 
 const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
-  const { account, connect, isWrongChain, switchToMainnet } = useNEVM();
+  const {
+    account,
+    connect,
+    expectedChainId,
+    isWrongChain,
+    switchToMainnet,
+  } = useNEVM();
   const { isEnabled } = useFeatureFlags();
   const {
     changeAccount,
@@ -46,6 +52,10 @@ const NEVMConnect: React.FC<NEVMConnectProps> = ({ setNevm, transfer }) => {
 
   const allowChange = transfer.status === "initialize";
   const hasNevmAddress = Boolean(transfer.nevmAddress);
+
+  if (!expectedChainId) {
+    return <Alert severity="error">NEVM network is not configured</Alert>;
+  }
   
   // If the address is already set but the user switched to a wrong EVM chain, prompt to switch back
   if (hasNevmAddress && isWrongChain) {

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -13,6 +13,7 @@ import {
   isNevmQueryReady,
   isPaliV2UtxoMode,
 } from "@contexts/PaliWallet/network-query-policy";
+import { normalizeEvmChainId } from "utils/network-config";
 
 interface INEVMContext {
   account?: string;
@@ -170,15 +171,14 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     }
   );
   const refetchChainId = chainId.refetch;
-  const expectedChainId = constants?.chain_id ?? MAINNET_CHAIN_ID;
-  const normalizedChainId =
-    typeof chainId.data === "string" ? chainId.data.toLowerCase() : undefined;
-  const normalizedExpectedChainId = expectedChainId.toLowerCase();
-  const isExpectedChain = normalizedChainId === normalizedExpectedChainId;
+  const expectedChainId =
+    normalizeEvmChainId(constants?.chain_id) ?? MAINNET_CHAIN_ID;
+  const normalizedChainId = normalizeEvmChainId(chainId.data);
+  const isExpectedChain = normalizedChainId === expectedChainId;
   const isWrongChain = Boolean(
     isEnabled &&
       normalizedChainId &&
-      normalizedChainId !== normalizedExpectedChainId
+      normalizedChainId !== expectedChainId
   );
 
   const sendTransaction = (config: TransactionConfig) => {
@@ -192,7 +192,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     window.ethereum
       .request({
         method: "wallet_switchEthereumChain",
-        params: [{ chainId: constants?.chain_id ?? MAINNET_CHAIN_ID }],
+        params: [{ chainId: expectedChainId }],
       })
       .then(() => chainId.refetch())
       .catch((err) => {
@@ -202,7 +202,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
           // Create network params in EIP-3085 format with Pali wallet extensions
           const networkParams = {
             ...NEVMNetwork,
-            chainId: constants?.chain_id ?? MAINNET_CHAIN_ID,
+            chainId: expectedChainId,
             // Override with dynamic values from constants if available
             ...(constants && {
               rpcUrls: [constants.rpc.nevm],

--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -13,14 +13,17 @@ import {
   isNevmQueryReady,
   isPaliV2UtxoMode,
 } from "@contexts/PaliWallet/network-query-policy";
-import { normalizeEvmChainId } from "utils/network-config";
+import {
+  normalizeEvmChainId,
+  resolveExpectedEvmChainId,
+} from "utils/network-config";
 
 interface INEVMContext {
   account?: string;
   balance?: string;
   isTestnet: boolean;
   chainId?: string;
-  expectedChainId: string;
+  expectedChainId?: string;
   isExpectedChain: boolean;
   isWrongChain: boolean;
   switchToMainnet: () => void;
@@ -171,12 +174,17 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     }
   );
   const refetchChainId = chainId.refetch;
-  const expectedChainId =
-    normalizeEvmChainId(constants?.chain_id) ?? MAINNET_CHAIN_ID;
+  const expectedChainId = resolveExpectedEvmChainId(
+    constants?.chain_id,
+    MAINNET_CHAIN_ID
+  );
   const normalizedChainId = normalizeEvmChainId(chainId.data);
-  const isExpectedChain = normalizedChainId === expectedChainId;
+  const isExpectedChain = Boolean(
+    expectedChainId && normalizedChainId === expectedChainId
+  );
   const isWrongChain = Boolean(
     isEnabled &&
+      expectedChainId &&
       normalizedChainId &&
       normalizedChainId !== expectedChainId
   );
@@ -189,6 +197,13 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
   };
 
   const switchToMainnet = () => {
+    if (!expectedChainId) {
+      const error = new Error("Configured NEVM chain ID is invalid");
+      captureException(error);
+      console.error(error.message);
+      return;
+    }
+
     window.ethereum
       .request({
         method: "wallet_switchEthereumChain",

--- a/utils/network-config.test.ts
+++ b/utils/network-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import {
   getSyscoinChainId,
   isSyscoinTestnetHost,
+  normalizeEvmChainId,
   resolveSyscoinIsTestnet,
 } from "./network-config";
 
@@ -25,6 +26,20 @@ describe("Syscoin network configuration", () => {
   it("returns the matching Syscoin UTXO and NEVM chain id", () => {
     expect(getSyscoinChainId(false)).toBe(57);
     expect(getSyscoinChainId(true)).toBe(5700);
+  });
+
+  it("normalizes decimal and hexadecimal EVM chain ids", () => {
+    expect(normalizeEvmChainId("57")).toBe("0x39");
+    expect(normalizeEvmChainId(57)).toBe("0x39");
+    expect(normalizeEvmChainId("0x39")).toBe("0x39");
+    expect(normalizeEvmChainId("0X0039")).toBe("0x39");
+    expect(normalizeEvmChainId("5700")).toBe("0x1644");
+  });
+
+  it("rejects invalid EVM chain ids", () => {
+    expect(normalizeEvmChainId(undefined)).toBeUndefined();
+    expect(normalizeEvmChainId("57-nevm")).toBeUndefined();
+    expect(normalizeEvmChainId(-1)).toBeUndefined();
   });
 
   it("recognizes the Tanenbaum and Vercel testnet hosts", () => {

--- a/utils/network-config.test.ts
+++ b/utils/network-config.test.ts
@@ -3,6 +3,7 @@ import {
   getSyscoinChainId,
   isSyscoinTestnetHost,
   normalizeEvmChainId,
+  resolveExpectedEvmChainId,
   resolveSyscoinIsTestnet,
 } from "./network-config";
 
@@ -40,6 +41,16 @@ describe("Syscoin network configuration", () => {
     expect(normalizeEvmChainId(undefined)).toBeUndefined();
     expect(normalizeEvmChainId("57-nevm")).toBeUndefined();
     expect(normalizeEvmChainId(-1)).toBeUndefined();
+  });
+
+  it("uses the default EVM chain only when configuration is missing", () => {
+    expect(resolveExpectedEvmChainId(undefined, "0x39")).toBe("0x39");
+    expect(resolveExpectedEvmChainId("", "0x39")).toBe("0x39");
+    expect(resolveExpectedEvmChainId("5700", "0x39")).toBe("0x1644");
+  });
+
+  it("fails closed when the configured EVM chain is invalid", () => {
+    expect(resolveExpectedEvmChainId("5700-nevm", "0x39")).toBeUndefined();
   });
 
   it("recognizes the Tanenbaum and Vercel testnet hosts", () => {

--- a/utils/network-config.ts
+++ b/utils/network-config.ts
@@ -47,6 +47,19 @@ export const normalizeEvmChainId = (chainId: unknown) => {
   return `0x${numericChainId.toString(16)}`;
 };
 
+export const resolveExpectedEvmChainId = (
+  configuredChainId: unknown,
+  defaultChainId: unknown
+) => {
+  const isMissing =
+    configuredChainId === undefined ||
+    configuredChainId === null ||
+    (typeof configuredChainId === "string" &&
+      configuredChainId.trim() === "");
+
+  return normalizeEvmChainId(isMissing ? defaultChainId : configuredChainId);
+};
+
 export const isSyscoinTestnetHost = (hostname?: string | null) => {
   const normalizedHostname = hostname?.split(":")[0].toLowerCase();
 

--- a/utils/network-config.ts
+++ b/utils/network-config.ts
@@ -25,6 +25,28 @@ export const resolveSyscoinIsTestnet = (
 export const getSyscoinChainId = (isTestnet: boolean) =>
   isTestnet ? SYSCOIN_TESTNET_CHAIN_ID : SYSCOIN_MAINNET_CHAIN_ID;
 
+export const normalizeEvmChainId = (chainId: unknown) => {
+  if (typeof chainId !== "string" && typeof chainId !== "number") {
+    return undefined;
+  }
+
+  const value = typeof chainId === "string" ? chainId.trim() : chainId;
+  if (
+    (typeof value === "string" &&
+      !/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(value)) ||
+    value === ""
+  ) {
+    return undefined;
+  }
+
+  const numericChainId = Number(value);
+  if (!Number.isSafeInteger(numericChainId) || numericChainId < 0) {
+    return undefined;
+  }
+
+  return `0x${numericChainId.toString(16)}`;
+};
+
 export const isSyscoinTestnetHost = (hostname?: string | null) => {
   const normalizedHostname = hostname?.split(":")[0].toLowerCase();
 


### PR DESCRIPTION
## Summary
- canonicalize configured and wallet-reported EVM chain IDs before comparison
- accept decimal and hexadecimal chain-ID formats without false wrong-network state
- send canonical hexadecimal chain IDs to wallet switch/add methods

## Verification
- `npm test -- --runInBand` — 13 suites, 82 tests passed
- `npm run lint` — passed (one pre-existing warning)
- `npm run build` — passed
- `npm exec -- tsc --noEmit` — passed