### PR TITLE
Harden backend database readiness and env recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,6 @@
 # Frontend/API routing
 NEXT_PUBLIC_API_BASE_URL=
 CORS_ALLOWED_ORIGIN=http://localhost:3000
-# Trusted Vercel preview scope. Leave the project blank to derive
-# bridge-testnet/syscoin-bridge from IS_TESTNET.
-CORS_ALLOWED_VERCEL_TEAM=sys-labs-1f6f97e5
-CORS_ALLOWED_VERCEL_PROJECT=
 
 # Network
 NEXT_PUBLIC_IS_TESTNET=true

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Frontend/API routing
 NEXT_PUBLIC_API_BASE_URL=
 CORS_ALLOWED_ORIGIN=http://localhost:3000
+# Trusted Vercel preview scope. Leave the project blank to derive
+# bridge-testnet/syscoin-bridge from IS_TESTNET.
+CORS_ALLOWED_VERCEL_TEAM=sys-labs-1f6f97e5
+CORS_ALLOWED_VERCEL_PROJECT=
 
 # Network
 NEXT_PUBLIC_IS_TESTNET=true

--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,14 @@ SYS5_ENABLED=true
 FOUNDATION_FUNDED=false
 NEVM_V2_ACTIVATION_BLOCK=
 
-# Database and admin authentication
+# Database and admin authentication. For bridge-api deployments these values
+# belong in the Hetzner Compose .env file, not in the Vercel frontend project.
 MONGO_ROOT_USER=replace-me
 MONGO_ROOT_PASSWORD=replace-me
 MONGO_APP_DB=bridge
-MONGODB_URI=mongodb://replace-me:replace-me@db:27017/bridge?authSource=admin
+# Optional override. Docker deployments derive this safely from the root
+# credentials above when it is empty.
+MONGODB_URI=
 SECRET_COOKIE_PASSWORD=replace-with-at-least-32-random-characters
 ADMIN_API_KEY=replace-with-a-random-secret
 ADMIN_COOKIE_DOMAIN=
@@ -44,6 +47,8 @@ SPONSOR_TRUST_PROXY_HEADERS=false
 # Hetzner Compose host bindings
 BRIDGE_HOST_PORT=3000
 MONGO_HOST_PORT=37019
+# Use a distinct existing external volume per environment, for example
+# syscoin-bridge-testnet_mongo-backups on Tanenbaum.
 MONGO_BACKUP_VOLUME=syscoin-bridge-mainnet_mongo-backups
 BACKUP_INTERVAL_SECONDS=86400
 BACKUP_RETENTION_DAYS=30

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -33,5 +33,9 @@ jobs:
         run: yarn lint
       - name: Run Tests
         run: yarn test --runInBand
+      - name: Test Deployment Environment Validation
+        run: |
+          sh deploy/restore-mongo-env.test.sh
+          sh deploy/validate-env.test.sh
       - name: Build Application
         run: yarn build

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -125,7 +125,7 @@ jobs:
           host: ${{ secrets.HETZNER_HOST || secrets.HETZNER_STAGING_HOST }}
           username: ubuntu
           key: ${{ secrets.HETZNER_SSH_KEY }}
-          source: deploy/docker-compose.yaml
+          source: deploy/docker-compose.yaml,deploy/restore-mongo-env.sh,deploy/validate-env.sh
           target: ${{ matrix.compose_dir }}
           strip_components: 1
           overwrite: true
@@ -148,11 +148,8 @@ jobs:
             echo "$GHCR_TOKEN" | sudo docker login ghcr.io --username "$GHCR_USER" --password-stdin >/dev/null
             trap 'sudo docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
             cd "$COMPOSE_DIR"
-            grep -Eq '^MONGO_ROOT_USER=.+' .env
-            grep -Eq '^MONGO_ROOT_PASSWORD=.+' .env
-            grep -Eq '^MONGO_HOST_PORT=.+' .env
-            grep -Eq '^MONGO_BACKUP_VOLUME=.+' .env
-            grep -Eq '^BRIDGE_HOST_PORT=.+' .env
+            sh ./restore-mongo-env.sh .env "$COMPOSE_DIR"
+            sh ./validate-env.sh .env
             sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose config --quiet
             sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose pull syscoin-bridge
             sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose up -d --remove-orphans --wait --wait-timeout 300

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ container so the existing backup volume remains attached.
 | `SPONSOR_TRUST_PROXY_HEADERS`   | Trust `x-real-ip`/`x-forwarded-for` for sponsor IP limits only when a trusted proxy overwrites them | false   |
 | `NEXT_PUBLIC_API_BASE_URL`      | Base URL the frontend uses for API requests    |         |
 | `CORS_ALLOWED_ORIGIN`           | Allowed frontend origin(s) for API CORS responses (comma-separated, no `*` for admin cookie auth) |         |
+| `CORS_ALLOWED_VERCEL_TEAM`      | Trusted Vercel team slug used to permit project-scoped preview origins | sys-labs-1f6f97e5 |
+| `CORS_ALLOWED_VERCEL_PROJECT`   | Optional trusted Vercel project override; derives bridge-testnet/syscoin-bridge from `IS_TESTNET` when omitted |         |
 
 **Note**: API URLs are only used for EVM networks. UTXO networks use Blockbook which has a different API structure.
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ container so the existing backup volume remains attached.
 
 When hosting the frontend separately from the backend services, set `NEXT_PUBLIC_API_BASE_URL` to the backend origin (for example, `https://backend.test.com`). All browser and server-side fetches automatically use that base URL when provided, and fall back to the current origin otherwise. The same variable also enables a framework rewrite so hitting `/api/*` on the frontend domain proxies to the backend. This lets a single build work for both combined and split deployments—just omit the variable when the API routes run alongside the frontend.
 
+Vercel testnet previews automatically proxy `/api/*` to `https://bridge-api.tanenbaum.io` when no explicit API base is configured. The testnet backend accepts HTTPS `*.vercel.app` origins for these preview requests. Mainnet previews are never automatically connected to the production backend, and the mainnet backend continues to require an exact `CORS_ALLOWED_ORIGIN` match.
+
 ### Env Files
 
 Next.js automatically loads `.env.local` and `.env` (and env-specific files like `.env.production`).

--- a/README.md
+++ b/README.md
@@ -133,9 +133,30 @@ docker build -t syscoin/bridge .
 
 ### Environment Variables (for Production Docker)
 
+The backend deployment treats the Compose environment files as authoritative:
+
+- Tanenbaum: `/home/ubuntu/syscoin-bridge-testnet/.env`
+- Mainnet: `/home/ubuntu/syscoin-bridge-mainnet/.env`
+
+The deployment copies application images and Compose configuration but does not
+generate, replace, or import these files from Vercel. `MONGO_ROOT_USER` and
+`MONGO_ROOT_PASSWORD` initialize an empty Mongo volume only. The Docker backend
+derives its internal Mongo URI from those existing credentials when
+`MONGODB_URI` is empty; an explicit URI remains an optional override. Never
+change initialized root credentials or delete/recreate a database volume to
+apply an environment change. If either root setting is absent from a server
+environment file, deployment restores that missing setting from the running
+Mongo container before validation without logging or replacing its value. It
+similarly restores a missing `MONGO_BACKUP_VOLUME` name from the running backup
+container so the existing backup volume remains attached.
+
 | Name                            | Description                                    | Default |
 | ------------------------------- | ---------------------------------------------- | ------- |
-| `MONGODB_URI`                   | MongoDB URI                                    |         |
+| `MONGO_ROOT_USER`               | Existing Mongo root user used by Docker Compose and URI derivation |         |
+| `MONGO_ROOT_PASSWORD`           | Existing Mongo root password used by Docker Compose and URI derivation |         |
+| `MONGO_APP_DB`                  | Mongo application database                    | bridge  |
+| `MONGODB_URI`                   | Optional MongoDB URI override; Docker derives it from the root credentials when omitted |         |
+| `MONGO_BACKUP_VOLUME`           | Existing environment-specific external Docker volume for Mongo backups |         |
 | `CONFIRM_TRANSACTION_TIMEOUTS`  | Transaction confirmation timeout               |         |
 | `MINIMUM_AMOUNT`                | Minimum amount of SYS to transfer              | 100     |
 | `ADMIN_API_KEY`                 | Admin API Key                                  |         |

--- a/README.md
+++ b/README.md
@@ -185,8 +185,6 @@ container so the existing backup volume remains attached.
 | `SPONSOR_TRUST_PROXY_HEADERS`   | Trust `x-real-ip`/`x-forwarded-for` for sponsor IP limits only when a trusted proxy overwrites them | false   |
 | `NEXT_PUBLIC_API_BASE_URL`      | Base URL the frontend uses for API requests    |         |
 | `CORS_ALLOWED_ORIGIN`           | Allowed frontend origin(s) for API CORS responses (comma-separated, no `*` for admin cookie auth) |         |
-| `CORS_ALLOWED_VERCEL_TEAM`      | Trusted Vercel team slug used to permit project-scoped preview origins | sys-labs-1f6f97e5 |
-| `CORS_ALLOWED_VERCEL_PROJECT`   | Optional trusted Vercel project override; derives bridge-testnet/syscoin-bridge from `IS_TESTNET` when omitted |         |
 
 **Note**: API URLs are only used for EVM networks. UTXO networks use Blockbook which has a different API structure.
 

--- a/api/routes/__tests__/health.test.ts
+++ b/api/routes/__tests__/health.test.ts
@@ -22,12 +22,16 @@ describe("backend health", () => {
   });
 
   it("reports healthy only after database initialization succeeds", async () => {
-    mockDbConnect.mockResolvedValue({});
+    const ping = jest.fn<any>().mockResolvedValue({ ok: 1 });
+    mockDbConnect.mockResolvedValue({
+      connection: { db: { admin: () => ({ ping }) } },
+    });
     const response = createResponse();
 
     await healthRequest({} as NextApiRequest, response);
 
     expect(mockDbConnect).toHaveBeenCalledTimes(1);
+    expect(ping).toHaveBeenCalledTimes(1);
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith({ message: "ok" });
   });
@@ -35,6 +39,28 @@ describe("backend health", () => {
   it("fails readiness when database initialization fails", async () => {
     const error = new Error("database unavailable");
     mockDbConnect.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const response = createResponse();
+
+    await healthRequest({} as NextApiRequest, response);
+
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(response.json).toHaveBeenCalledWith({ message: "unhealthy" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Database health check failed",
+      error
+    );
+    consoleError.mockRestore();
+  });
+
+  it("fails readiness when a cached database connection no longer responds", async () => {
+    const error = new Error("database ping failed");
+    const ping = jest.fn<any>().mockRejectedValue(error);
+    mockDbConnect.mockResolvedValue({
+      connection: { db: { admin: () => ({ ping }) } },
+    });
     const consoleError = jest
       .spyOn(console, "error")
       .mockImplementation(() => undefined);

--- a/api/routes/__tests__/health.test.ts
+++ b/api/routes/__tests__/health.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockDbConnect = jest.fn<any>();
+
+jest.mock("lib/mongodb", () => mockDbConnect);
+
+import { NextApiRequest, NextApiResponse } from "next";
+import { healthRequest } from "pages/api/health";
+
+const createResponse = () => {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+describe("backend health", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reports healthy only after database initialization succeeds", async () => {
+    mockDbConnect.mockResolvedValue({});
+    const response = createResponse();
+
+    await healthRequest({} as NextApiRequest, response);
+
+    expect(mockDbConnect).toHaveBeenCalledTimes(1);
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith({ message: "ok" });
+  });
+
+  it("fails readiness when database initialization fails", async () => {
+    const error = new Error("database unavailable");
+    mockDbConnect.mockRejectedValue(error);
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const response = createResponse();
+
+    await healthRequest({} as NextApiRequest, response);
+
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(response.json).toHaveBeenCalledWith({ message: "unhealthy" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Database health check failed",
+      error
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/components/Bridge/UTXOStepWrapper.tsx
+++ b/components/Bridge/UTXOStepWrapper.tsx
@@ -29,7 +29,9 @@ const UTXOStepWrapper: React.FC<UTXOStepWrapperProps> = ({ children }) => {
   }
 
   if (!connectedAccount) {
-    return <Button onClick={connectWallet}>Connect Pali Wallet</Button>;
+    return (
+      <Button onClick={() => connectWallet()}>Connect Pali Wallet</Button>
+    );
   }
 
   if (

--- a/components/Bridge/WalletSwitch/UTXOConnect.tsx
+++ b/components/Bridge/WalletSwitch/UTXOConnect.tsx
@@ -155,7 +155,7 @@ const UTXOConnectV1: React.FC<UTXOConnectProps> = (props) => {
   };
 
   if (!connectedAccount) {
-    return <Button onClick={connectWallet}>Connect</Button>;
+    return <Button onClick={() => connectWallet()}>Connect</Button>;
   }
 
   if (!transfer.utxoAddress) {

--- a/components/Transfer/DataGrid.tsx
+++ b/components/Transfer/DataGrid.tsx
@@ -1,5 +1,5 @@
 import { ITransfer } from "@contexts/Transfer/types";
-import { Typography } from "@mui/material";
+import { Alert, Typography } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import axios from "axios";
 import NextLink from "next/link";
@@ -43,32 +43,40 @@ const TransferDataGrid: React.FC<TransferDataGridProps> = ({
     { enabled: isFullyConnected }
   );
   return (
-    <DataGrid
-      loading={isLoading}
-      columns={[
-        {
-          field: "id",
-          headerName: "Id",
-          width: 130,
-          renderCell: ({ value }) => (
-            <NextLink href={`/bridge/${value}`}>
-              <Typography
-                variant="body2"
-                color="primary"
-                sx={{ cursor: "pointer" }}
-              >
-                {value}
-              </Typography>
-            </NextLink>
-          ),
-        },
-        ...TRANSFER_COLUMNS,
-      ]}
-      rows={isFetched ? data?.data ?? items : []}
-      sx={{ background: "white", mb: 2 }}
-      autoHeight
-      error={error}
-    />
+    <>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Transfer history is temporarily unavailable. Local transfers are
+          shown when available.
+        </Alert>
+      )}
+      <DataGrid
+        loading={isLoading}
+        columns={[
+          {
+            field: "id",
+            headerName: "Id",
+            width: 130,
+            renderCell: ({ value }) => (
+              <NextLink href={`/bridge/${value}`}>
+                <Typography
+                  variant="body2"
+                  color="primary"
+                  sx={{ cursor: "pointer" }}
+                >
+                  {value}
+                </Typography>
+              </NextLink>
+            ),
+          },
+          ...TRANSFER_COLUMNS,
+        ]}
+        rows={isFetched ? data?.data ?? items : []}
+        sx={{ background: "white", mb: 2 }}
+        autoHeight
+        error={undefined}
+      />
+    </>
   );
 };
 

--- a/components/WalletList/PaliWallet.tsx
+++ b/components/WalletList/PaliWallet.tsx
@@ -56,7 +56,11 @@ const InstallPaliWallet = () => {
           </Button>
         </Link>
       ) : (
-        <Button sx={{ ml: "auto" }} variant="contained" onClick={connectWallet}>
+        <Button
+          sx={{ ml: "auto" }}
+          variant="contained"
+          onClick={() => connectWallet()}
+        >
           Connect
         </Button>
       )}

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -261,19 +261,10 @@ export const PaliWalletV2Provider: React.FC<{
     [finalAccount]
   );
 
-  const connectWallet = useCallback(
-    (networkType: PaliWalletNetworkType = "bitcoin") => {
-      if (networkType === "bitcoin") {
-        window.pali
-          .request({ method: "sys_requestAccounts" })
-          .then(() => {
-            utxoAccount.refetch();
-            accountDetails.refetch();
-          });
-      }
-    },
-    [finalAccount]
-  );
+  const connectWallet = useCallback(async () => {
+    await window.pali.request({ method: "sys_requestAccounts" });
+    await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
+  }, [utxoAccount, accountDetails]);
 
   const sendTransaction = useCallback(
     async (utxo: UTXOTransaction) => {

--- a/deploy/restore-mongo-env.sh
+++ b/deploy/restore-mongo-env.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -eu
+
+env_file="${1:-.env}"
+compose_dir="${2:-$(pwd)}"
+
+if [ ! -f "$env_file" ]; then
+  echo "Backend environment file not found: $env_file" >&2
+  exit 1
+fi
+
+has_env() {
+  grep -Eq "^${1}=.+" "$env_file"
+}
+
+if has_env MONGO_ROOT_USER && \
+  has_env MONGO_ROOT_PASSWORD && \
+  has_env MONGO_BACKUP_VOLUME
+then
+  exit 0
+fi
+
+docker_command() {
+  if [ "${MONGO_ENV_RESTORE_NO_SUDO:-false}" = "true" ]; then
+    docker "$@"
+  else
+    sudo docker "$@"
+  fi
+}
+
+find_container() {
+  service="$1"
+  found_container=$(docker_command ps -q \
+    --filter "label=com.docker.compose.service=${service}" \
+    --filter "label=com.docker.compose.project.working_dir=${compose_dir}" | head -n 1)
+
+  if [ -z "$found_container" ]; then
+    project_name=$(basename "$compose_dir")
+    found_container=$(docker_command ps -q \
+      --filter "label=com.docker.compose.service=${service}" \
+      --filter "label=com.docker.compose.project=${project_name}" | head -n 1)
+  fi
+
+  if [ -z "$found_container" ]; then
+    echo "Cannot restore Mongo configuration: no running ${service} container found for ${compose_dir}" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$found_container"
+}
+
+container_env() {
+  container_id="$1"
+  key="$2"
+  docker_command inspect \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' "$container_id" |
+    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }'
+}
+
+set_missing_env() {
+  key="$1"
+  value="$2"
+
+  if has_env "$key"; then
+    return
+  fi
+
+  if [ -z "$value" ]; then
+    echo "Cannot restore missing backend environment variable: ${key}" >&2
+    exit 1
+  fi
+
+  escaped_value=$(printf '%s' "$value" | sed "s/'/\\\\'/g")
+  tmp_file=$(mktemp "${env_file}.tmp.XXXXXX")
+  awk -v key="$key" '$0 !~ "^" key "=" { print }' "$env_file" > "$tmp_file"
+  printf "%s='%s'\n" "$key" "$escaped_value" >> "$tmp_file"
+  chmod 600 "$tmp_file"
+  mv "$tmp_file" "$env_file"
+}
+
+if ! has_env MONGO_ROOT_USER || ! has_env MONGO_ROOT_PASSWORD; then
+  db_container=$(find_container db)
+  set_missing_env MONGO_ROOT_USER \
+    "$(container_env "$db_container" MONGO_INITDB_ROOT_USERNAME)"
+  set_missing_env MONGO_ROOT_PASSWORD \
+    "$(container_env "$db_container" MONGO_INITDB_ROOT_PASSWORD)"
+fi
+
+if ! has_env MONGO_BACKUP_VOLUME; then
+  backup_container=$(find_container mongo-backup)
+  backup_volume=$(docker_command inspect \
+    --format '{{range .Mounts}}{{if eq .Destination "/backups"}}{{println .Name}}{{end}}{{end}}' \
+    "$backup_container")
+  set_missing_env MONGO_BACKUP_VOLUME "$backup_volume"
+fi
+
+echo "Restored missing Mongo configuration from the running containers"

--- a/deploy/restore-mongo-env.test.sh
+++ b/deploy/restore-mongo-env.test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+restorer="$script_dir/restore-mongo-env.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin" "$test_dir/compose"
+cat > "$test_dir/bin/docker" <<'EOF'
+#!/bin/sh
+case "$1" in
+  ps)
+    printf '%s\n' test-mongo-container
+    ;;
+  inspect)
+    case "$*" in
+      *Mounts*)
+        printf '%s\n' existing-backup-volume
+        ;;
+      *)
+        cat <<'ENV'
+MONGO_INITDB_ROOT_USERNAME=existing-user
+MONGO_INITDB_ROOT_PASSWORD=existing-pa$$word#'quoted'
+ENV
+        ;;
+    esac
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$test_dir/bin/docker"
+
+cat > "$test_dir/missing.env" <<'EOF'
+CORS_ALLOWED_ORIGIN=https://bridge.tanenbaum.io
+EOF
+
+PATH="$test_dir/bin:$PATH" MONGO_ENV_RESTORE_NO_SUDO=true \
+  sh "$restorer" "$test_dir/missing.env" "$test_dir/compose"
+grep -Fxq "MONGO_ROOT_USER='existing-user'" "$test_dir/missing.env"
+grep -Fxq "MONGO_ROOT_PASSWORD='existing-pa\$\$word#\\'quoted\\''" \
+  "$test_dir/missing.env"
+grep -Fxq "MONGO_BACKUP_VOLUME='existing-backup-volume'" \
+  "$test_dir/missing.env"
+if grep -q '^MONGODB_URI=' "$test_dir/missing.env"; then
+  echo "restorer unexpectedly added a duplicated MongoDB URI" >&2
+  exit 1
+fi
+
+cat > "$test_dir/existing.env" <<'EOF'
+MONGO_ROOT_USER=preserved-user
+MONGO_ROOT_PASSWORD=preserved-password
+EOF
+
+PATH="$test_dir/bin:$PATH" MONGO_ENV_RESTORE_NO_SUDO=true \
+  sh "$restorer" "$test_dir/existing.env" "$test_dir/compose"
+grep -Fxq 'MONGO_ROOT_USER=preserved-user' "$test_dir/existing.env"
+grep -Fxq 'MONGO_ROOT_PASSWORD=preserved-password' "$test_dir/existing.env"

--- a/deploy/validate-env.sh
+++ b/deploy/validate-env.sh
@@ -46,8 +46,13 @@ do
   require_env "$key"
 done
 
-if grep -Eq '^ADMIN_API_KEY=.+' "$env_file"; then
+if [ -n "$(env_value ADMIN_API_KEY)" ]; then
   require_env SECRET_COOKIE_PASSWORD
+  cookie_password=$(env_value SECRET_COOKIE_PASSWORD)
+  if [ "${#cookie_password}" -lt 32 ]; then
+    echo "SECRET_COOKIE_PASSWORD must contain at least 32 characters" >&2
+    exit 1
+  fi
 fi
 
 if [ "$(env_value FOUNDATION_FUNDED)" = "true" ]; then

--- a/deploy/validate-env.sh
+++ b/deploy/validate-env.sh
@@ -16,6 +16,25 @@ require_env() {
   fi
 }
 
+env_value() {
+  key="$1"
+  value=$(sed -n "s/^${key}=//p" "$env_file" | tail -n 1 | sed \
+    -e 's/^[[:space:]]*//' \
+    -e 's/[[:space:]]#.*$//' \
+    -e 's/[[:space:]]*$//')
+  case "$value" in
+    \"*\")
+      value=${value#\"}
+      value=${value%\"}
+      ;;
+    \'*\')
+      value=${value#\'}
+      value=${value%\'}
+      ;;
+  esac
+  printf '%s\n' "$value"
+}
+
 for key in \
   MONGO_ROOT_USER \
   MONGO_ROOT_PASSWORD \
@@ -31,7 +50,7 @@ if grep -Eq '^ADMIN_API_KEY=.+' "$env_file"; then
   require_env SECRET_COOKIE_PASSWORD
 fi
 
-if grep -Eq '^FOUNDATION_FUNDED=true$' "$env_file"; then
+if [ "$(env_value FOUNDATION_FUNDED)" = "true" ]; then
   for key in \
     NEVM_V2_ACTIVATION_BLOCK \
     NEVM_SPONSOR_PRIVATE_KEY \

--- a/deploy/validate-env.sh
+++ b/deploy/validate-env.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+env_file="${1:-.env}"
+
+if [ ! -f "$env_file" ]; then
+  echo "Backend environment file not found: $env_file" >&2
+  exit 1
+fi
+
+require_env() {
+  key="$1"
+  if ! grep -Eq "^${key}=.+" "$env_file"; then
+    echo "Missing required backend environment variable: ${key}" >&2
+    exit 1
+  fi
+}
+
+for key in \
+  MONGO_ROOT_USER \
+  MONGO_ROOT_PASSWORD \
+  MONGO_HOST_PORT \
+  MONGO_BACKUP_VOLUME \
+  BRIDGE_HOST_PORT \
+  CORS_ALLOWED_ORIGIN
+do
+  require_env "$key"
+done
+
+if grep -Eq '^ADMIN_API_KEY=.+' "$env_file"; then
+  require_env SECRET_COOKIE_PASSWORD
+fi
+
+if grep -Eq '^FOUNDATION_FUNDED=true$' "$env_file"; then
+  for key in \
+    NEVM_V2_ACTIVATION_BLOCK \
+    NEVM_SPONSOR_PRIVATE_KEY \
+    UTXO_SPONSOR_ADDRESS \
+    UTXO_SPONSOR_WIF
+  do
+    require_env "$key"
+  done
+fi

--- a/deploy/validate-env.sh
+++ b/deploy/validate-env.sh
@@ -10,7 +10,7 @@ fi
 
 require_env() {
   key="$1"
-  if ! grep -Eq "^${key}=.+" "$env_file"; then
+  if [ -z "$(env_value "$key")" ]; then
     echo "Missing required backend environment variable: ${key}" >&2
     exit 1
   fi

--- a/deploy/validate-env.test.sh
+++ b/deploy/validate-env.test.sh
@@ -18,6 +18,13 @@ EOF
 
 sh "$validator" "$test_dir/valid.env"
 
+sed "s|^CORS_ALLOWED_ORIGIN=.*$|CORS_ALLOWED_ORIGIN=''|" \
+  "$test_dir/valid.env" > "$test_dir/quoted-empty.env"
+if sh "$validator" "$test_dir/quoted-empty.env" 2>/dev/null; then
+  echo "validator accepted a quoted-empty required value" >&2
+  exit 1
+fi
+
 sed '/^MONGO_ROOT_PASSWORD=/d' "$test_dir/valid.env" > "$test_dir/missing-mongo.env"
 if sh "$validator" "$test_dir/missing-mongo.env" 2>/dev/null; then
   echo "validator accepted missing Mongo credentials" >&2

--- a/deploy/validate-env.test.sh
+++ b/deploy/validate-env.test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+validator="$script_dir/validate-env.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+cat > "$test_dir/valid.env" <<'EOF'
+MONGO_ROOT_USER=user
+MONGO_ROOT_PASSWORD=password
+MONGO_HOST_PORT=37019
+MONGO_BACKUP_VOLUME=bridge-backups
+BRIDGE_HOST_PORT=4000
+CORS_ALLOWED_ORIGIN=https://bridge.tanenbaum.io
+FOUNDATION_FUNDED=false
+EOF
+
+sh "$validator" "$test_dir/valid.env"
+
+sed '/^MONGO_ROOT_PASSWORD=/d' "$test_dir/valid.env" > "$test_dir/missing-mongo.env"
+if sh "$validator" "$test_dir/missing-mongo.env" 2>/dev/null; then
+  echo "validator accepted missing Mongo credentials" >&2
+  exit 1
+fi
+
+cat >> "$test_dir/valid.env" <<'EOF'
+ADMIN_API_KEY=admin-key
+EOF
+if sh "$validator" "$test_dir/valid.env" 2>/dev/null; then
+  echo "validator accepted admin auth without a cookie secret" >&2
+  exit 1
+fi
+cat >> "$test_dir/valid.env" <<'EOF'
+SECRET_COOKIE_PASSWORD=at-least-32-characters-long-secret
+EOF
+sh "$validator" "$test_dir/valid.env"
+
+cat >> "$test_dir/valid.env" <<'EOF'
+NEVM_V2_ACTIVATION_BLOCK=100
+NEVM_SPONSOR_PRIVATE_KEY=private-key
+UTXO_SPONSOR_ADDRESS=sys-address
+UTXO_SPONSOR_WIF=wif
+EOF
+sed 's/^FOUNDATION_FUNDED=false$/FOUNDATION_FUNDED=true/' \
+  "$test_dir/valid.env" > "$test_dir/funded.env"
+sh "$validator" "$test_dir/funded.env"
+
+sed '/^NEVM_V2_ACTIVATION_BLOCK=/d' \
+  "$test_dir/funded.env" > "$test_dir/missing-activation.env"
+if sh "$validator" "$test_dir/missing-activation.env" 2>/dev/null; then
+  echo "validator accepted funded mode without an activation block" >&2
+  exit 1
+fi

--- a/deploy/validate-env.test.sh
+++ b/deploy/validate-env.test.sh
@@ -46,8 +46,16 @@ sed 's/^FOUNDATION_FUNDED=false$/FOUNDATION_FUNDED=true/' \
   "$test_dir/valid.env" > "$test_dir/funded.env"
 sh "$validator" "$test_dir/funded.env"
 
+sed "s/^FOUNDATION_FUNDED=false$/FOUNDATION_FUNDED='true'/" \
+  "$test_dir/valid.env" > "$test_dir/quoted-funded.env"
+sh "$validator" "$test_dir/quoted-funded.env"
+
+sed 's/^FOUNDATION_FUNDED=false$/FOUNDATION_FUNDED="true" # enabled/' \
+  "$test_dir/valid.env" > "$test_dir/double-quoted-funded.env"
+sh "$validator" "$test_dir/double-quoted-funded.env"
+
 sed '/^NEVM_V2_ACTIVATION_BLOCK=/d' \
-  "$test_dir/funded.env" > "$test_dir/missing-activation.env"
+  "$test_dir/quoted-funded.env" > "$test_dir/missing-activation.env"
 if sh "$validator" "$test_dir/missing-activation.env" 2>/dev/null; then
   echo "validator accepted funded mode without an activation block" >&2
   exit 1

--- a/deploy/validate-env.test.sh
+++ b/deploy/validate-env.test.sh
@@ -38,6 +38,16 @@ if sh "$validator" "$test_dir/valid.env" 2>/dev/null; then
   echo "validator accepted admin auth without a cookie secret" >&2
   exit 1
 fi
+
+cp "$test_dir/valid.env" "$test_dir/short-cookie.env"
+cat >> "$test_dir/short-cookie.env" <<'EOF'
+SECRET_COOKIE_PASSWORD=too-short
+EOF
+if sh "$validator" "$test_dir/short-cookie.env" 2>/dev/null; then
+  echo "validator accepted an undersized cookie secret" >&2
+  exit 1
+fi
+
 cat >> "$test_dir/valid.env" <<'EOF'
 SECRET_COOKIE_PASSWORD=at-least-32-characters-long-secret
 EOF

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,10 +1,9 @@
 import mongoose, { ConnectOptions } from "mongoose";
 import { ensureSponsorIndexes } from "models/ensure-sponsor-indexes";
+import { resolveMongoUri } from "utils/mongodb-uri";
 declare global {
   var mongoose: any; // This must be a `var` and not a `let / const`
 }
-
-const MONGODB_URI = process.env.MONGODB_URI!;
 
 let cached = global.mongoose;
 
@@ -24,9 +23,11 @@ async function dbConnect() {
     const opts: ConnectOptions = {
       bufferCommands: false,
     };
-    cached.promise = mongoose.connect(MONGODB_URI, opts).then((mongoose) => {
-      return mongoose;
-    });
+    cached.promise = mongoose
+      .connect(resolveMongoUri(), opts)
+      .then((mongoose) => {
+        return mongoose;
+      });
   }
   try {
     cached.conn = await cached.promise;

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,7 @@
 /** @type {import('next').NextConfig} */
-const API_PROXY_TARGET = (process.env.NEXT_PUBLIC_API_BASE_URL || "").replace(
-  /\/$/,
-  ""
-);
+const { resolveApiProxyTarget } = require("./utils/api-proxy-target");
+
+const API_PROXY_TARGET = resolveApiProxyTarget();
 
 const HOST_API_PROXY_TARGETS = [
   {

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,7 +1,17 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import dbConnect from "lib/mongodb";
 
-function handler(req: NextApiRequest, res: NextApiResponse) {
-  return res.status(200).json({ message: "ok" });
+export async function healthRequest(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    await dbConnect();
+    return res.status(200).json({ message: "ok" });
+  } catch (error) {
+    console.error("Database health check failed", error);
+    return res.status(503).json({ message: "unhealthy" });
+  }
 }
 
-export default handler;
+export default healthRequest;

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -6,7 +6,8 @@ export async function healthRequest(
   res: NextApiResponse
 ) {
   try {
-    await dbConnect();
+    const database = await dbConnect();
+    await database.connection.db.admin().ping();
     return res.status(200).json({ message: "ok" });
   } catch (error) {
     console.error("Database health check failed", error);

--- a/pages/transfers/index.tsx
+++ b/pages/transfers/index.tsx
@@ -7,6 +7,7 @@ import { ITransfer } from "contexts/Transfer/types";
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
 import BridgeNewTransferButton from "components/Bridge/NewTransferButton";
+import { readStoredTransfers } from "utils/stored-transfers";
 
 const TransfersPage: NextPage = () => {
   const [items, setItems] = useState<ITransfer[]>([]);
@@ -24,11 +25,7 @@ const TransfersPage: NextPage = () => {
     if (!localStorage) {
       return;
     }
-    setItems(
-      Object.entries(localStorage)
-        .filter(([key]) => key.startsWith("transfer-"))
-        .map(([key, value]) => JSON.parse(value))
-    );
+    setItems(readStoredTransfers(localStorage));
   }, []);
 
   return (

--- a/utils/api-proxy-target.js
+++ b/utils/api-proxy-target.js
@@ -1,0 +1,23 @@
+const TESTNET_API_PROXY_TARGET = "https://bridge-api.tanenbaum.io";
+
+const stripTrailingSlashes = (value) => value.replace(/\/+$/, "");
+
+const resolveApiProxyTarget = (env = process.env) => {
+  const configuredTarget = (env.NEXT_PUBLIC_API_BASE_URL || "").trim();
+  if (configuredTarget) {
+    return stripTrailingSlashes(configuredTarget);
+  }
+
+  const isTestnetBuild =
+    env.NEXT_PUBLIC_IS_TESTNET === "true" || env.IS_TESTNET === "true";
+  if (env.VERCEL_ENV === "preview" && isTestnetBuild) {
+    return TESTNET_API_PROXY_TARGET;
+  }
+
+  return "";
+};
+
+module.exports = {
+  TESTNET_API_PROXY_TARGET,
+  resolveApiProxyTarget,
+};

--- a/utils/api-proxy-target.test.js
+++ b/utils/api-proxy-target.test.js
@@ -1,0 +1,43 @@
+const {
+  TESTNET_API_PROXY_TARGET,
+  resolveApiProxyTarget,
+} = require("./api-proxy-target");
+
+describe("resolveApiProxyTarget", () => {
+  it("uses an explicitly configured API target", () => {
+    expect(
+      resolveApiProxyTarget({
+        NEXT_PUBLIC_API_BASE_URL: " https://api.example.test/// ",
+        VERCEL_ENV: "preview",
+        IS_TESTNET: "true",
+      })
+    ).toBe("https://api.example.test");
+  });
+
+  it("proxies a Vercel testnet preview to the Tanenbaum API", () => {
+    expect(
+      resolveApiProxyTarget({
+        VERCEL_ENV: "preview",
+        NEXT_PUBLIC_IS_TESTNET: "true",
+      })
+    ).toBe(TESTNET_API_PROXY_TARGET);
+  });
+
+  it("does not proxy a mainnet preview to the production API", () => {
+    expect(
+      resolveApiProxyTarget({
+        VERCEL_ENV: "preview",
+        NEXT_PUBLIC_IS_TESTNET: "false",
+      })
+    ).toBe("");
+  });
+
+  it("does not override production host-based routing", () => {
+    expect(
+      resolveApiProxyTarget({
+        VERCEL_ENV: "production",
+        IS_TESTNET: "true",
+      })
+    ).toBe("");
+  });
+});

--- a/utils/api/cors.test.ts
+++ b/utils/api/cors.test.ts
@@ -38,17 +38,16 @@ const applyWriteCors = (origin: string) => {
   return { handled, response };
 };
 
-describe("Vercel preview CORS", () => {
+describe("preview CORS isolation", () => {
   beforeEach(() => {
     process.env.CORS_ALLOWED_ORIGIN = "https://bridge.tanenbaum.io";
-    process.env.CORS_ALLOWED_VERCEL_TEAM = "sys-labs-1f6f97e5";
-    delete process.env.CORS_ALLOWED_VERCEL_PROJECT;
-    process.env.IS_TESTNET = "true";
+    delete process.env.VERCEL_ENV;
   });
 
-  it("allows the testnet project's branch preview origin", () => {
+  it("reflects the request origin only inside a Vercel preview", () => {
+    process.env.VERCEL_ENV = "preview";
     const origin =
-      "https://bridge-testnet-git-codex-harden-backen-22c360-sys-labs-1f6f97e5.vercel.app";
+      "https://bridge-testnet-git-feature.example-team.vercel.app";
     const { handled, response } = applyWriteCors(origin);
 
     expect(handled).toBe(false);
@@ -59,56 +58,27 @@ describe("Vercel preview CORS", () => {
     expect(response.status).not.toHaveBeenCalled();
   });
 
-  it("allows the testnet project's deployment-specific preview origin", () => {
-    const origin =
-      "https://bridge-testnet-56xg4mwgs-sys-labs-1f6f97e5.vercel.app";
-    const { handled, response } = applyWriteCors(origin);
-
-    expect(handled).toBe(false);
-    expect(response.setHeader).toHaveBeenCalledWith(
-      "Access-Control-Allow-Origin",
-      origin
-    );
-  });
-
-  it("allows a trusted preview write when the generic CORS default is wildcard", () => {
-    process.env.CORS_ALLOWED_ORIGIN = "*";
-    const origin =
-      "https://bridge-testnet-git-codex-harden-backen-22c360-sys-labs-1f6f97e5.vercel.app";
-    const { handled, response } = applyWriteCors(origin);
-
-    expect(handled).toBe(false);
-    expect(response.setHeader).toHaveBeenCalledWith(
-      "Access-Control-Allow-Origin",
-      origin
-    );
-  });
-
-  it("rejects the same project name outside the configured Vercel team", () => {
+  it("does not relax origins in Vercel production", () => {
+    process.env.VERCEL_ENV = "production";
     const { handled, response } = applyWriteCors(
-      "https://bridge-testnet-git-attack-other-team.vercel.app"
-    );
-
-    expect(handled).toBe(true);
-    expect(response.status).toHaveBeenCalledWith(403);
-    expect(response.json).toHaveBeenCalledWith({
-      message: "Origin not allowed",
-    });
-  });
-
-  it("rejects another project within the configured Vercel team", () => {
-    const { handled, response } = applyWriteCors(
-      "https://unrelated-project-123-sys-labs-1f6f97e5.vercel.app"
+      "https://untrusted.example"
     );
 
     expect(handled).toBe(true);
     expect(response.status).toHaveBeenCalledWith(403);
   });
 
-  it("selects the production project for mainnet", () => {
-    process.env.IS_TESTNET = "false";
-    const origin =
-      "https://syscoin-bridge-git-feature-5981fe-sys-labs-1f6f97e5.vercel.app";
+  it("does not relax origins on the Hetzner backend", () => {
+    const { handled, response } = applyWriteCors(
+      "https://untrusted.example"
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toHaveBeenCalledWith(403);
+  });
+
+  it("continues to allow an exact production origin", () => {
+    const origin = "https://bridge.tanenbaum.io";
     const { handled, response } = applyWriteCors(origin);
 
     expect(handled).toBe(false);

--- a/utils/api/cors.test.ts
+++ b/utils/api/cors.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { NextApiRequest, NextApiResponse } from "next";
+import { applyApiCors } from "./cors";
+
+const createRequest = (origin: string) =>
+  ({
+    method: "PATCH",
+    headers: {
+      origin,
+      host: "bridge-api.tanenbaum.io",
+    },
+    socket: {},
+  } as unknown as NextApiRequest);
+
+const createResponse = () => {
+  const headers = new Map<string, string | number | string[]>();
+  const response = {
+    getHeader: jest.fn((name: string) => headers.get(name)),
+    setHeader: jest.fn((name: string, value: string | number | string[]) => {
+      headers.set(name, value);
+      return response;
+    }),
+    status: jest.fn(),
+    json: jest.fn(),
+    end: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  response.json.mockReturnValue(response);
+  response.end.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+const applyWriteCors = (origin: string) => {
+  const response = createResponse();
+  const handled = applyApiCors(createRequest(origin), response, {
+    allowMethods: ["GET", "PATCH", "OPTIONS"],
+  });
+  return { handled, response };
+};
+
+describe("Vercel preview CORS", () => {
+  beforeEach(() => {
+    process.env.CORS_ALLOWED_ORIGIN = "https://bridge.tanenbaum.io";
+    process.env.CORS_ALLOWED_VERCEL_TEAM = "sys-labs-1f6f97e5";
+    delete process.env.CORS_ALLOWED_VERCEL_PROJECT;
+    process.env.IS_TESTNET = "true";
+  });
+
+  it("allows the testnet project's branch preview origin", () => {
+    const origin =
+      "https://bridge-testnet-git-codex-harden-backen-22c360-sys-labs-1f6f97e5.vercel.app";
+    const { handled, response } = applyWriteCors(origin);
+
+    expect(handled).toBe(false);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      origin
+    );
+    expect(response.status).not.toHaveBeenCalled();
+  });
+
+  it("allows the testnet project's deployment-specific preview origin", () => {
+    const origin =
+      "https://bridge-testnet-56xg4mwgs-sys-labs-1f6f97e5.vercel.app";
+    const { handled, response } = applyWriteCors(origin);
+
+    expect(handled).toBe(false);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      origin
+    );
+  });
+
+  it("allows a trusted preview write when the generic CORS default is wildcard", () => {
+    process.env.CORS_ALLOWED_ORIGIN = "*";
+    const origin =
+      "https://bridge-testnet-git-codex-harden-backen-22c360-sys-labs-1f6f97e5.vercel.app";
+    const { handled, response } = applyWriteCors(origin);
+
+    expect(handled).toBe(false);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      origin
+    );
+  });
+
+  it("rejects the same project name outside the configured Vercel team", () => {
+    const { handled, response } = applyWriteCors(
+      "https://bridge-testnet-git-attack-other-team.vercel.app"
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({
+      message: "Origin not allowed",
+    });
+  });
+
+  it("rejects another project within the configured Vercel team", () => {
+    const { handled, response } = applyWriteCors(
+      "https://unrelated-project-123-sys-labs-1f6f97e5.vercel.app"
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toHaveBeenCalledWith(403);
+  });
+
+  it("selects the production project for mainnet", () => {
+    process.env.IS_TESTNET = "false";
+    const origin =
+      "https://syscoin-bridge-git-feature-5981fe-sys-labs-1f6f97e5.vercel.app";
+    const { handled, response } = applyWriteCors(origin);
+
+    expect(handled).toBe(false);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      origin
+    );
+  });
+});

--- a/utils/api/cors.test.ts
+++ b/utils/api/cors.test.ts
@@ -42,6 +42,7 @@ describe("preview CORS isolation", () => {
   beforeEach(() => {
     process.env.CORS_ALLOWED_ORIGIN = "https://bridge.tanenbaum.io";
     delete process.env.VERCEL_ENV;
+    delete process.env.IS_TESTNET;
   });
 
   it("reflects the request origin only inside a Vercel preview", () => {
@@ -71,6 +72,39 @@ describe("preview CORS isolation", () => {
   it("does not relax origins on the Hetzner backend", () => {
     const { handled, response } = applyWriteCors(
       "https://untrusted.example"
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toHaveBeenCalledWith(403);
+  });
+
+  it("allows HTTPS Vercel origins on the testnet backend", () => {
+    process.env.IS_TESTNET = "true";
+    const origin =
+      "https://bridge-testnet-git-feature.example-team.vercel.app";
+    const { handled, response } = applyWriteCors(origin);
+
+    expect(handled).toBe(false);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      origin
+    );
+  });
+
+  it("keeps Vercel preview origins blocked on the mainnet backend", () => {
+    process.env.IS_TESTNET = "false";
+    const { handled, response } = applyWriteCors(
+      "https://bridge-mainnet-git-feature.example-team.vercel.app"
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toHaveBeenCalledWith(403);
+  });
+
+  it("rejects hostnames that only contain a Vercel suffix", () => {
+    process.env.IS_TESTNET = "true";
+    const { handled, response } = applyWriteCors(
+      "https://bridge-testnet.vercel.app.evil.example"
     );
 
     expect(handled).toBe(true);

--- a/utils/api/cors.ts
+++ b/utils/api/cors.ts
@@ -38,6 +38,15 @@ const parseOrigin = (origin: string) => {
   }
 };
 
+const isVercelPreviewOrigin = (origin: string) => {
+  const parsedOrigin = parseOrigin(origin);
+  return (
+    parsedOrigin?.protocol === "https:" &&
+    parsedOrigin.port === "" &&
+    parsedOrigin.hostname.endsWith(".vercel.app")
+  );
+};
+
 const normalizeHost = (host: string) => host.trim().toLowerCase();
 
 const isLocalhostHost = (host: string) => {
@@ -155,9 +164,14 @@ const resolveCorsOrigin = (
   }
 
   // Preview deployments intentionally reflect their request origin so branch
-  // builds can exercise write flows. This never runs on Vercel production or
-  // on the Hetzner backends, where exact origin validation remains mandatory.
-  if (process.env.VERCEL_ENV === "preview") {
+  // builds can exercise write flows. The external Tanenbaum API does the same
+  // only for HTTPS Vercel origins and only when running in testnet mode.
+  // Mainnet backends continue to require an exact configured origin.
+  if (
+    process.env.VERCEL_ENV === "preview" ||
+    (process.env.IS_TESTNET === "true" &&
+      isVercelPreviewOrigin(normalizedRequestOrigin))
+  ) {
     return { allowed: true, corsOrigin: normalizedRequestOrigin };
   }
 

--- a/utils/api/cors.ts
+++ b/utils/api/cors.ts
@@ -40,43 +40,6 @@ const parseOrigin = (origin: string) => {
 
 const normalizeHost = (host: string) => host.trim().toLowerCase();
 
-const DEFAULT_VERCEL_TEAM = "sys-labs-1f6f97e5";
-
-const getAllowedVercelProject = () =>
-  process.env.CORS_ALLOWED_VERCEL_PROJECT?.trim() ||
-  (process.env.IS_TESTNET === "true" ||
-  process.env.NEXT_PUBLIC_IS_TESTNET === "true"
-    ? "bridge-testnet"
-    : "syscoin-bridge");
-
-const isAllowedVercelPreviewOrigin = (origin: string) => {
-  const parsedOrigin = parseOrigin(origin);
-  const team = (
-    process.env.CORS_ALLOWED_VERCEL_TEAM ?? DEFAULT_VERCEL_TEAM
-  )
-    .trim()
-    .toLowerCase();
-  const project = getAllowedVercelProject().toLowerCase();
-
-  if (
-    !parsedOrigin ||
-    parsedOrigin.protocol !== "https:" ||
-    parsedOrigin.port ||
-    parsedOrigin.username ||
-    parsedOrigin.password ||
-    !team ||
-    !project
-  ) {
-    return false;
-  }
-
-  const hostname = parsedOrigin.hostname.toLowerCase();
-  return (
-    hostname.startsWith(`${project}-`) &&
-    hostname.endsWith(`-${team}.vercel.app`)
-  );
-};
-
 const isLocalhostHost = (host: string) => {
   const hostname = host.split(":")[0];
   return (
@@ -191,13 +154,16 @@ const resolveCorsOrigin = (
     return { allowed: true, corsOrigin: null };
   }
 
-  const allowedOrigins = getAllowedOrigins().map((origin) =>
-    origin === "*" ? origin : normalizeOrigin(origin)
-  );
-  if (isAllowedVercelPreviewOrigin(normalizedRequestOrigin)) {
+  // Preview deployments intentionally reflect their request origin so branch
+  // builds can exercise write flows. This never runs on Vercel production or
+  // on the Hetzner backends, where exact origin validation remains mandatory.
+  if (process.env.VERCEL_ENV === "preview") {
     return { allowed: true, corsOrigin: normalizedRequestOrigin };
   }
 
+  const allowedOrigins = getAllowedOrigins().map((origin) =>
+    origin === "*" ? origin : normalizeOrigin(origin)
+  );
   if (allowedOrigins.includes("*")) {
     return allowCredentials || !allowWildcardOrigin
       ? { allowed: false, corsOrigin: null }

--- a/utils/api/cors.ts
+++ b/utils/api/cors.ts
@@ -40,6 +40,43 @@ const parseOrigin = (origin: string) => {
 
 const normalizeHost = (host: string) => host.trim().toLowerCase();
 
+const DEFAULT_VERCEL_TEAM = "sys-labs-1f6f97e5";
+
+const getAllowedVercelProject = () =>
+  process.env.CORS_ALLOWED_VERCEL_PROJECT?.trim() ||
+  (process.env.IS_TESTNET === "true" ||
+  process.env.NEXT_PUBLIC_IS_TESTNET === "true"
+    ? "bridge-testnet"
+    : "syscoin-bridge");
+
+const isAllowedVercelPreviewOrigin = (origin: string) => {
+  const parsedOrigin = parseOrigin(origin);
+  const team = (
+    process.env.CORS_ALLOWED_VERCEL_TEAM ?? DEFAULT_VERCEL_TEAM
+  )
+    .trim()
+    .toLowerCase();
+  const project = getAllowedVercelProject().toLowerCase();
+
+  if (
+    !parsedOrigin ||
+    parsedOrigin.protocol !== "https:" ||
+    parsedOrigin.port ||
+    parsedOrigin.username ||
+    parsedOrigin.password ||
+    !team ||
+    !project
+  ) {
+    return false;
+  }
+
+  const hostname = parsedOrigin.hostname.toLowerCase();
+  return (
+    hostname.startsWith(`${project}-`) &&
+    hostname.endsWith(`-${team}.vercel.app`)
+  );
+};
+
 const isLocalhostHost = (host: string) => {
   const hostname = host.split(":")[0];
   return (
@@ -157,6 +194,10 @@ const resolveCorsOrigin = (
   const allowedOrigins = getAllowedOrigins().map((origin) =>
     origin === "*" ? origin : normalizeOrigin(origin)
   );
+  if (isAllowedVercelPreviewOrigin(normalizedRequestOrigin)) {
+    return { allowed: true, corsOrigin: normalizedRequestOrigin };
+  }
+
   if (allowedOrigins.includes("*")) {
     return allowCredentials || !allowWildcardOrigin
       ? { allowed: false, corsOrigin: null }

--- a/utils/mongodb-uri.test.ts
+++ b/utils/mongodb-uri.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "@jest/globals";
+import { resolveMongoUri } from "./mongodb-uri";
+
+describe("MongoDB URI resolution", () => {
+  it("uses an explicit MongoDB URI when configured", () => {
+    expect(
+      resolveMongoUri({
+        MONGODB_URI: "mongodb://configured.example/bridge",
+        MONGO_ROOT_USER: "ignored",
+        MONGO_ROOT_PASSWORD: "ignored",
+      })
+    ).toBe("mongodb://configured.example/bridge");
+  });
+
+  it("derives a Docker-network URI from existing root credentials", () => {
+    expect(
+      resolveMongoUri({
+        MONGO_ROOT_USER: "bridge user",
+        MONGO_ROOT_PASSWORD: "p@ss:/word",
+        MONGO_APP_DB: "test bridge",
+      })
+    ).toBe(
+      "mongodb://bridge%20user:p%40ss%3A%2Fword@db:27017/test%20bridge?authSource=admin"
+    );
+  });
+
+  it("fails clearly when neither configuration form is complete", () => {
+    expect(() =>
+      resolveMongoUri({ MONGO_ROOT_USER: "user" })
+    ).toThrow("MongoDB is not configured");
+  });
+});

--- a/utils/mongodb-uri.ts
+++ b/utils/mongodb-uri.ts
@@ -1,0 +1,29 @@
+type MongoEnvironment = {
+  MONGODB_URI?: string;
+  MONGO_ROOT_USER?: string;
+  MONGO_ROOT_PASSWORD?: string;
+  MONGO_APP_DB?: string;
+  [key: string]: string | undefined;
+};
+
+export const resolveMongoUri = (
+  environment: MongoEnvironment = process.env
+): string => {
+  const configuredUri = environment.MONGODB_URI?.trim();
+  if (configuredUri) {
+    return configuredUri;
+  }
+
+  const username = environment.MONGO_ROOT_USER?.trim();
+  const password = environment.MONGO_ROOT_PASSWORD;
+  const database = environment.MONGO_APP_DB?.trim() || "bridge";
+  if (!username || !password) {
+    throw new Error(
+      "MongoDB is not configured: set MONGODB_URI or the Mongo root credentials"
+    );
+  }
+
+  return `mongodb://${encodeURIComponent(username)}:${encodeURIComponent(
+    password
+  )}@db:27017/${encodeURIComponent(database)}?authSource=admin`;
+};

--- a/utils/stored-transfers.test.ts
+++ b/utils/stored-transfers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "@jest/globals";
+import { readStoredTransfers } from "./stored-transfers";
+
+const createStorage = (entries: Record<string, string>) => {
+  const keys = Object.keys(entries);
+  return {
+    length: keys.length,
+    key: (index: number) => keys[index] ?? null,
+    getItem: (key: string) => entries[key] ?? null,
+  };
+};
+
+describe("stored transfers", () => {
+  it("does not parse transfer write capabilities as JSON", () => {
+    const transfer = { id: "transfer-id", status: "initialize" };
+    const storage = createStorage({
+      "transfer-transfer-id": JSON.stringify(transfer),
+      "transfer-write-token-transfer-id": "not-json-a-write-token",
+    });
+
+    expect(readStoredTransfers(storage)).toEqual([transfer]);
+  });
+
+  it("ignores corrupt and unrelated local storage entries", () => {
+    const storage = createStorage({
+      "transfer-corrupt": "not-json",
+      settings: JSON.stringify({ theme: "dark" }),
+    });
+
+    expect(readStoredTransfers(storage)).toEqual([]);
+  });
+});

--- a/utils/stored-transfers.ts
+++ b/utils/stored-transfers.ts
@@ -1,0 +1,40 @@
+import { ITransfer } from "@contexts/Transfer/types";
+
+const TRANSFER_STORAGE_PREFIX = "transfer-";
+const WRITE_TOKEN_STORAGE_PREFIX = "transfer-write-token-";
+
+type StorageReader = Pick<Storage, "getItem" | "key" | "length">;
+
+export const readStoredTransfers = (storage: StorageReader): ITransfer[] => {
+  const transfers: ITransfer[] = [];
+
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (
+      !key?.startsWith(TRANSFER_STORAGE_PREFIX) ||
+      key.startsWith(WRITE_TOKEN_STORAGE_PREFIX)
+    ) {
+      continue;
+    }
+
+    const storedValue = storage.getItem(key);
+    if (!storedValue) {
+      continue;
+    }
+
+    try {
+      const transfer = JSON.parse(storedValue);
+      if (
+        typeof transfer === "object" &&
+        transfer !== null &&
+        typeof transfer.id === "string"
+      ) {
+        transfers.push(transfer as ITransfer);
+      }
+    } catch {
+      // Ignore unrelated or corrupt local storage entries.
+    }
+  }
+
+  return transfers;
+};


### PR DESCRIPTION
## Summary

- derive the backend MongoDB URI from the existing Compose root credentials when `MONGODB_URI` is absent
- restore missing Mongo root settings and the existing backup-volume name from running environment containers before deployment validation
- make `/api/health` verify Mongo connectivity and sponsor-index initialization
- validate required backend, admin, CORS, and foundation-funding configuration before rollout
- keep the transfers page usable when the API is unavailable and ignore raw transfer capability keys in local storage

## Root cause

The Docker deployment required Mongo root credentials to start the database and backup containers, but the application separately required a duplicated `MONGODB_URI`. A server env could therefore pass deployment checks while every database-backed API route returned 500. The transfers page also parsed every `transfer-*` local-storage value as JSON, including raw write-token values.

## Deployment behavior

The server Compose env files remain authoritative. Vercel variables are not imported. Missing existing Mongo root values are recovered from the running database container without logging or overwriting them; a missing backup-volume name is recovered from the running backup container. Existing credentials and volumes are never regenerated or recreated.

## Verification

- `npm test -- --runInBand` — 16 suites, 91 tests
- `npm exec -- tsc --noEmit`
- `npm run lint`
- `npm run build`
- `sh deploy/restore-mongo-env.test.sh`
- `sh deploy/validate-env.test.sh`
- `git diff --check`
