### PR TITLE
Fix managed Mongo authentication drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,9 @@ NEVM_V2_ACTIVATION_BLOCK=
 MONGO_ROOT_USER=replace-me
 MONGO_ROOT_PASSWORD=replace-me
 MONGO_APP_DB=bridge
-# Optional override. Docker deployments derive this safely from the root
-# credentials above when it is empty.
+# Optional override for non-Compose runtimes. The managed Docker Compose stack
+# always derives its local URI from the root credentials above and ignores this
+# legacy override so embedded credentials cannot drift.
 MONGODB_URI=
 SECRET_COOKIE_PASSWORD=replace-with-at-least-32-random-characters
 ADMIN_API_KEY=replace-with-a-random-secret

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -35,6 +35,7 @@ jobs:
         run: yarn test --runInBand
       - name: Test Deployment Environment Validation
         run: |
+          sh deploy/docker-compose.test.sh
           sh deploy/restore-mongo-env.test.sh
           sh deploy/validate-env.test.sh
       - name: Build Application

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -152,6 +152,31 @@ jobs:
             sh ./validate-env.sh .env
             sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose config --quiet
             sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose pull syscoin-bridge
+            db_container_id=$(sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose ps -q db)
+            if [ -n "$db_container_id" ]; then
+              sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose run --rm --no-deps \
+                --entrypoint node syscoin-bridge -e '
+                  const { MongoClient } = require("mongodb");
+                  const username = process.env.MONGO_ROOT_USER?.trim();
+                  const password = process.env.MONGO_ROOT_PASSWORD;
+                  const database = process.env.MONGO_APP_DB?.trim() || "bridge";
+                  if ((process.env.MONGODB_URI || "").trim()) {
+                    throw new Error("Managed Compose retained an explicit MongoDB URI");
+                  }
+                  if (!username || !password) {
+                    throw new Error("Managed Compose Mongo credentials are missing");
+                  }
+                  const uri = `mongodb://${encodeURIComponent(username)}:${encodeURIComponent(password)}@db:27017/${encodeURIComponent(database)}?authSource=admin`;
+                  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 10000 });
+                  client.db(database).command({ ping: 1 })
+                    .then(() => client.close())
+                    .catch(async (error) => {
+                      console.error("Mongo authentication preflight failed:", error.name);
+                      await client.close().catch(() => undefined);
+                      process.exit(1);
+                    });
+                '
+            fi
             if ! sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose up -d --remove-orphans --wait --wait-timeout 300; then
               sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose ps || true
               sudo env BRIDGE_IMAGE="$BRIDGE_IMAGE" docker-compose logs --tail=200 syscoin-bridge || true

--- a/README.md
+++ b/README.md
@@ -141,21 +141,23 @@ The backend deployment treats the Compose environment files as authoritative:
 The deployment copies application images and Compose configuration but does not
 generate, replace, or import these files from Vercel. `MONGO_ROOT_USER` and
 `MONGO_ROOT_PASSWORD` initialize an empty Mongo volume only. The Docker backend
-derives its internal Mongo URI from those existing credentials when
-`MONGODB_URI` is empty; an explicit URI remains an optional override. Never
-change initialized root credentials or delete/recreate a database volume to
-apply an environment change. Before validation, deployment reconciles the root
-settings from the healthy running Mongo container without logging them. It also
-recovers the existing data, configuration, and backup volume names from the
-running containers. All three volumes are then attached as explicit external
-volumes, so Compose never offers to recreate an existing Mongo data volume.
+derives its internal Mongo URI from those existing credentials. The managed
+Compose service explicitly ignores `MONGODB_URI` so a legacy URI with embedded
+credentials cannot drift from the initialized database volume; the override
+remains available to non-Compose runtimes. Never change initialized root
+credentials or delete/recreate a database volume to apply an environment
+change. Before validation, deployment reconciles the root settings from the
+healthy running Mongo container without logging them. It also recovers the
+existing data, configuration, and backup volume names from the running
+containers. All three volumes are then attached as explicit external volumes,
+so Compose never offers to recreate an existing Mongo data volume.
 
 | Name                            | Description                                    | Default |
 | ------------------------------- | ---------------------------------------------- | ------- |
 | `MONGO_ROOT_USER`               | Existing Mongo root user used by Docker Compose and URI derivation |         |
 | `MONGO_ROOT_PASSWORD`           | Existing Mongo root password used by Docker Compose and URI derivation |         |
 | `MONGO_APP_DB`                  | Mongo application database                    | bridge  |
-| `MONGODB_URI`                   | Optional MongoDB URI override; Docker derives it from the root credentials when omitted |         |
+| `MONGODB_URI`                   | Optional MongoDB URI override for non-Compose runtimes; managed Compose ignores it |         |
 | `MONGO_DATA_VOLUME`             | Existing external Mongo `/data/db` volume name |         |
 | `MONGO_CONFIG_VOLUME`           | Existing external Mongo `/data/configdb` volume name |         |
 | `MONGO_BACKUP_VOLUME`           | Existing environment-specific external Docker volume for Mongo backups |         |

--- a/deploy/docker-compose.test.sh
+++ b/deploy/docker-compose.test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+cat > "$test_dir/backend.env" <<'EOF'
+MONGO_ROOT_USER=compose-user
+MONGO_ROOT_PASSWORD=compose-password
+MONGO_APP_DB=bridge
+MONGODB_URI=mongodb://stale-user:stale-password@db:27017/bridge?authSource=admin
+MONGO_HOST_PORT=47019
+MONGO_DATA_VOLUME=compose-data
+MONGO_CONFIG_VOLUME=compose-config
+MONGO_BACKUP_VOLUME=compose-backups
+BRIDGE_HOST_PORT=4000
+SECRET_COOKIE_PASSWORD=01234567890123456789012345678901
+ADMIN_API_KEY=test-admin-key
+EOF
+
+compose_config() {
+  if command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    docker compose "$@"
+  fi
+}
+
+BRIDGE_ENV_FILE="$test_dir/backend.env" \
+  compose_config \
+    --env-file "$test_dir/backend.env" \
+    -f "$script_dir/docker-compose.yaml" \
+    config --format json |
+  node -e '
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { input += chunk; });
+    process.stdin.on("end", () => {
+      const config = JSON.parse(input);
+      const bridge = config.services["syscoin-bridge"].environment;
+      if (bridge.MONGODB_URI !== "") {
+        throw new Error("Managed Compose retained a stale MongoDB URI");
+      }
+      if (bridge.MONGO_ROOT_USER !== "compose-user" ||
+          bridge.MONGO_ROOT_PASSWORD !== "compose-password") {
+        throw new Error("Managed Compose lost the reconciled Mongo credentials");
+      }
+    });
+  '
+
+echo "Docker Compose Mongo configuration tests passed"

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -86,6 +86,10 @@ services:
     environment:
       NODE_ENV: production
       HOSTNAME: 0.0.0.0
+      # This managed Compose stack always uses its local authenticated Mongo.
+      # Ignore legacy URIs whose embedded credentials can drift from the
+      # initialized database volume.
+      MONGODB_URI: ""
     ports:
       - "127.0.0.1:${BRIDGE_HOST_PORT:?BRIDGE_HOST_PORT is required}:3000"
     healthcheck:


### PR DESCRIPTION
## Summary
- ignore legacy MONGODB_URI values inside the managed Compose bridge service
- verify Mongo authentication with the pulled bridge image before replacing a running deployment
- add Compose regression coverage and document the managed-runtime behavior

## Failure addressed
Tanenbaum Mongo and backup containers were healthy, but the bridge used an overriding stale URI and failed with Mongo code 18 AuthenticationFailed.

## Validation
- sh deploy/docker-compose.test.sh
- sh deploy/restore-mongo-env.test.sh
- sh deploy/validate-env.test.sh
- npm test -- --runInBand
- npm run lint
- tsc --noEmit
- npm run build