### PR TITLE
Fix first-load Pali UTXO connection

### DIFF
--- a/components/Bridge/WalletSwitch/UTXOConnect.tsx
+++ b/components/Bridge/WalletSwitch/UTXOConnect.tsx
@@ -15,7 +15,10 @@ import WalletSwitchCard from "./Card";
 import WalletSwitchConfirmCard from "./ConfirmCard";
 import { MIN_GAS_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
-import { switchToSyscoinThenChangeAccount } from "@contexts/PaliWallet/utxo-network";
+import {
+  hasPaliUtxoAccountDetails,
+  switchToSyscoinThenChangeAccount,
+} from "@contexts/PaliWallet/utxo-network";
 
 export type AssetType = "sys" | "sysx" | "none";
 
@@ -181,6 +184,7 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     connectedAccount,
     xpubAddress,
     changeAccount,
+    connectWallet,
   } = usePaliWalletV2();
 
   const setTransferUtxo = () => {
@@ -188,12 +192,20 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     setUtxo({ xpub: xpubAddress, address: connectedAccount });
   };
 
-  const change = () =>
-    switchToSyscoinThenChangeAccount(
+  const change = () => {
+    if (
+      isBitcoinBased &&
+      !hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)
+    ) {
+      return connectWallet();
+    }
+
+    return switchToSyscoinThenChangeAccount(
       isBitcoinBased,
       switchTo,
       changeAccount
     );
+  };
 
   const hasUtxoAddress = Boolean(transfer.utxoAddress);
 
@@ -210,6 +222,14 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     return (
       <Button variant="contained" onClick={() => switchTo("bitcoin")}>
         Set UTXO Account
+      </Button>
+    );
+  }
+
+  if (!hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)) {
+    return (
+      <Button variant="contained" onClick={() => connectWallet()}>
+        Connect Pali Wallet
       </Button>
     );
   }

--- a/components/Bridge/WalletSwitch/UTXOConnect.tsx
+++ b/components/Bridge/WalletSwitch/UTXOConnect.tsx
@@ -16,6 +16,7 @@ import WalletSwitchConfirmCard from "./ConfirmCard";
 import { MIN_GAS_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
 import {
+  connectPaliUtxoAccount,
   hasPaliUtxoAccountDetails,
   switchToSyscoinThenChangeAccount,
 } from "@contexts/PaliWallet/utxo-network";
@@ -192,12 +193,20 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     setUtxo({ xpub: xpubAddress, address: connectedAccount });
   };
 
+  const connect = () =>
+    connectPaliUtxoAccount(
+      connectedAccount,
+      xpubAddress,
+      switchTo,
+      connectWallet
+    );
+
   const change = () => {
     if (
       isBitcoinBased &&
       !hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)
     ) {
-      return connectWallet();
+      return connect();
     }
 
     return switchToSyscoinThenChangeAccount(
@@ -228,7 +237,7 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
 
   if (!hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)) {
     return (
-      <Button variant="contained" onClick={() => connectWallet()}>
+      <Button variant="contained" onClick={connect}>
         Connect Pali Wallet
       </Button>
     );

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -21,6 +21,7 @@ import {
   PaliWalletNetworkType,
 } from "./network-query-policy";
 import {
+  discoverPaliUtxoAccount,
   getPaliSyscoinSwitchRequest,
   readPaliBitcoinBasedState,
 } from "./utxo-network";
@@ -139,72 +140,25 @@ export const PaliWalletV2Provider: React.FC<{
     enabled: isInstalled && typeof window !== "undefined",
   });
 
-  const requestAccounts = () => {
+  const requestAccounts = useCallback(() => {
     return window.pali.request({
       method: "sys_requestAccounts",
     }) as Promise<(string | { success: boolean })[]>;
-  };
+  }, []);
 
-  // UTXO connection query - only run when on UTXO network or already connected
+  // Automatic queries may only discover an existing connection. Opening the
+  // account picker here can create a hidden pending request before the user
+  // clicks Connect, causing every later wallet action to appear unresponsive.
   const utxoAccount = useQuery(["pali", "utxo-account"], {
-    queryFn: async () => {
-      try {
-        // First check if we already have an account
-        try {
-          const existingAccount = await window.pali.request({
-            method: "wallet_getAccount",
-          });
-          if (existingAccount) {
-            return existingAccount.address; // Return address if already connected
-          }
-        } catch {
-          // No existing account, proceed with connection
-        }
-
-        // Connect using sys_requestAccounts (now returns address like eth_requestAccounts)
-        const result = await window.pali.request({
-          method: "sys_requestAccounts",
-        });
-
-        if (
-          result.length === 0 ||
-          (typeof result[0] !== "string" &&
-            result[0].success === false)
-        ) {
-          return null;
-        }
-
-        // sys_requestAccounts now returns address (consistent with eth_requestAccounts)
-        return result[0]; // This is the address
-      } catch (error: any) {
-        // Network switch and other user cancellations are handled the same way
-        // The simplified popup system means all rejections are user cancellations
-        
-        // Check if this is a user cancellation error
-        if (error?.message?.includes('Request cancelled') || 
-            error?.message?.includes('User rejected') ||
-            error?.message?.includes('popup closure') ||
-            error?.message?.includes('cancelled') ||
-            error?.message?.includes('Network switch was cancelled') ||
-            error?.message?.includes('Duplicate') ||
-            error?.code === 4001 ||
-            error?.code === -32603) { // Internal error often means user cancellation
-          console.log('User cancelled UTXO connection request:', error?.message);
-          return null; // Return null instead of throwing to prevent cascade
-        }
-        
-        console.error('sys_requestAccounts failed:', error);
-        return null; // Return null instead of throwing to prevent cascade for CORS errors
-      }
-    },
+    queryFn: () => discoverPaliUtxoAccount(window.pali),
     enabled: isPaliUtxoQueryReady(
       isInstalled,
       isBitcoinBased.isFetched,
       isBitcoinBased.data,
       isSwitchingToUtxo
     ),
-    retry: false, // Don't retry user interaction methods
-    refetchOnWindowFocus: false, // Don't refetch on focus
+    retry: false,
+    refetchOnWindowFocus: false,
   });
 
   // Get full account details (including xpub) after connection
@@ -262,9 +216,20 @@ export const PaliWalletV2Provider: React.FC<{
   );
 
   const connectWallet = useCallback(async () => {
-    await window.pali.request({ method: "sys_requestAccounts" });
-    await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
-  }, [utxoAccount, accountDetails]);
+    const result = await requestAccounts();
+    const selectedAccount = result[0];
+    if (
+      !selectedAccount ||
+      (typeof selectedAccount !== "string" && !selectedAccount.success)
+    ) {
+      return;
+    }
+
+    const { data: discoveredAccount } = await utxoAccount.refetch();
+    if (discoveredAccount) {
+      await accountDetails.refetch();
+    }
+  }, [requestAccounts, utxoAccount, accountDetails]);
 
   const sendTransaction = useCallback(
     async (utxo: UTXOTransaction) => {

--- a/contexts/PaliWallet/utxo-network.test.ts
+++ b/contexts/PaliWallet/utxo-network.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import {
+  discoverPaliUtxoAccount,
   getPaliSyscoinSwitchRequest,
+  hasPaliUtxoAccountDetails,
   readPaliBitcoinBasedState,
   switchToSyscoinThenChangeAccount,
 } from "./utxo-network";
 
 describe("Pali Syscoin UTXO network handling", () => {
+  it("discovers an existing account without opening an interactive request", async () => {
+    const request = jest.fn(async () => ({ address: "sys1-existing" }));
+
+    await expect(discoverPaliUtxoAccount({ request })).resolves.toBe(
+      "sys1-existing"
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({ method: "wallet_getAccount" });
+  });
+
+  it("stays disconnected when silent discovery fails", async () => {
+    const request = jest.fn(async () => {
+      throw new Error("Not connected");
+    });
+
+    await expect(discoverPaliUtxoAccount({ request })).resolves.toBeNull();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).not.toHaveBeenCalledWith({ method: "sys_requestAccounts" });
+  });
+
+  it("requires both an address and xpub before showing account controls", () => {
+    expect(hasPaliUtxoAccountDetails(undefined, undefined)).toBe(false);
+    expect(hasPaliUtxoAccountDetails("sys1-address", undefined)).toBe(false);
+    expect(hasPaliUtxoAccountDetails(undefined, "xpub-value")).toBe(false);
+    expect(hasPaliUtxoAccountDetails("sys1-address", "xpub-value")).toBe(
+      true
+    );
+  });
+
   it("uses the UTXO chain-switch method for Syscoin mainnet", () => {
     expect(getPaliSyscoinSwitchRequest(false, true)).toEqual({
       method: "sys_switchChain",

--- a/contexts/PaliWallet/utxo-network.test.ts
+++ b/contexts/PaliWallet/utxo-network.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import {
+  connectPaliUtxoAccount,
   discoverPaliUtxoAccount,
   getPaliSyscoinSwitchRequest,
   hasPaliUtxoAccountDetails,
@@ -35,6 +36,59 @@ describe("Pali Syscoin UTXO network handling", () => {
     expect(hasPaliUtxoAccountDetails("sys1-address", "xpub-value")).toBe(
       true
     );
+  });
+
+  it("switches an account discovered on the opposite Syscoin network before connecting", async () => {
+    const calls: string[] = [];
+    const switchTo = jest.fn(async () => {
+      calls.push("switch");
+    });
+    const connectAccount = jest.fn(async () => {
+      calls.push("connect");
+    });
+
+    await connectPaliUtxoAccount(
+      undefined,
+      "xpub-from-opposite-network",
+      switchTo,
+      connectAccount
+    );
+
+    expect(calls).toEqual(["switch", "connect"]);
+    expect(switchTo).toHaveBeenCalledWith("bitcoin");
+  });
+
+  it("connects directly when no opposite-network account was discovered", async () => {
+    const switchTo = jest.fn(async () => undefined);
+    const connectAccount = jest.fn(async () => undefined);
+
+    await connectPaliUtxoAccount(
+      undefined,
+      undefined,
+      switchTo,
+      connectAccount
+    );
+
+    expect(switchTo).not.toHaveBeenCalled();
+    expect(connectAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not request an account when the configured-chain switch is rejected", async () => {
+    const switchError = new Error("Network switch rejected");
+    const switchTo = jest.fn(async () => {
+      throw switchError;
+    });
+    const connectAccount = jest.fn(async () => undefined);
+
+    await expect(
+      connectPaliUtxoAccount(
+        undefined,
+        "xpub-from-opposite-network",
+        switchTo,
+        connectAccount
+      )
+    ).rejects.toBe(switchError);
+    expect(connectAccount).not.toHaveBeenCalled();
   });
 
   it("uses the UTXO chain-switch method for Syscoin mainnet", () => {

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -15,6 +15,8 @@ type PaliNetworkSwitch = (
 
 type PaliAccountChange = () => Promise<unknown>;
 
+type PaliAccountConnect = () => unknown | Promise<unknown>;
+
 type PaliUtxoAccount = {
   address?: unknown;
 };
@@ -41,6 +43,22 @@ export const hasPaliUtxoAccountDetails = (
   address: string | undefined,
   xpub: string | undefined
 ) => Boolean(address && xpub);
+
+export const connectPaliUtxoAccount = async (
+  address: string | undefined,
+  xpub: string | undefined,
+  switchTo: PaliNetworkSwitch,
+  connectAccount: PaliAccountConnect
+) => {
+  // An xpub without a valid address means Pali discovered an account on the
+  // opposite Syscoin network. Move to the bridge's configured chain before
+  // opening the account request, otherwise the returned address stays invalid.
+  if (!address && xpub) {
+    await switchTo("bitcoin");
+  }
+
+  return connectAccount();
+};
 
 export const getPaliSyscoinSwitchRequest = (
   isTestnet: boolean,

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -15,6 +15,33 @@ type PaliNetworkSwitch = (
 
 type PaliAccountChange = () => Promise<unknown>;
 
+type PaliUtxoAccount = {
+  address?: unknown;
+};
+
+export const discoverPaliUtxoAccount = async (
+  provider: Pick<PaliProvider, "request">
+): Promise<string | null> => {
+  try {
+    const account = (await provider.request({
+      method: "wallet_getAccount",
+    })) as PaliUtxoAccount | null;
+
+    return typeof account?.address === "string" && account.address
+      ? account.address
+      : null;
+  } catch {
+    // Discovery must stay silent and non-interactive. A connection prompt is
+    // only allowed from an explicit user action.
+    return null;
+  }
+};
+
+export const hasPaliUtxoAccountDetails = (
+  address: string | undefined,
+  xpub: string | undefined
+) => Boolean(address && xpub);
+
 export const getPaliSyscoinSwitchRequest = (
   isTestnet: boolean,
   isAlreadyOnUtxo: boolean


### PR DESCRIPTION
## Summary
- keep automatic Pali UTXO account discovery non-interactive
- call sys_requestAccounts only after an explicit Connect click
- replace empty Change and Set controls with Connect Pali Wallet until address and xpub are available
- retain existing account and network switching behavior after connection

## Root cause
The first-load UTXO query fell back from wallet_getAccount to sys_requestAccounts automatically. On a fresh Pali install that interactive request could remain pending without a visible popup, suppressing later Connect and Change requests as duplicates. SET also had no account data and intentionally returned without action.

## Validation
- 18 Jest suites and 106 tests pass
- TypeScript passes
- lint passes with one pre-existing hook warning
- production build passes
- git diff check passes