### PR TITLE
Fix claim-gas detection for mixed SYS/SYSX UTXOs

### DIFF
--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -1045,7 +1045,7 @@ describe("SponsorWalletService", () => {
       SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
       (global.fetch as jest.Mock<any>).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ balance: "100000" }),
+        json: () => Promise.resolve([{ value: "100000" }]),
       });
 
       const service = new SponsorWalletService();
@@ -1060,10 +1060,10 @@ describe("SponsorWalletService", () => {
         reason: "Destination UTXO address already has claim gas",
       });
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/v2/address/sys1destination?details=basic")
+        expect.stringContaining("/api/v2/utxo/sys1destination")
       );
       expect(global.fetch).not.toHaveBeenCalledWith(
-        expect.stringContaining("/api/v2/xpub/xpub")
+        expect.stringContaining("/api/v2/utxo/xpub")
       );
     });
 
@@ -1072,11 +1072,11 @@ describe("SponsorWalletService", () => {
       (global.fetch as jest.Mock<any>)
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "100000" }),
+          json: () => Promise.resolve([{ value: "100000" }]),
         });
 
       const service = new SponsorWalletService();
@@ -1091,11 +1091,79 @@ describe("SponsorWalletService", () => {
         reason: "Connected UTXO wallet already has claim gas",
       });
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/v2/address/sys1destination?details=basic")
+        expect.stringContaining("/api/v2/utxo/sys1destination")
       );
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/v2/xpub/xpub?details=basic")
+        expect.stringContaining("/api/v2/utxo/xpub")
       );
+    });
+
+    it("does not count SYS locked in asset-bearing UTXOs as claim gas", async () => {
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      (global.fetch as jest.Mock<any>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                value: "2989998650",
+                assetInfo: {
+                  assetGuid: "123456",
+                  value: "10000000",
+                },
+              },
+            ]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                value: "2989998650",
+                assetInfo: {
+                  assetGuid: "123456",
+                  value: "10000000",
+                },
+              },
+            ]),
+        });
+
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.getUtxoClaimGasFundingStatus(transfer)
+      ).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("sums only pure SYS outputs when checking claim gas", async () => {
+      SponsorWalletTransactionsMock.findOne.mockResolvedValue(null);
+      (global.fetch as jest.Mock<any>).mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            {
+              value: "2989998650",
+              assetInfo: {
+                assetGuid: "123456",
+                value: "10000000",
+              },
+            },
+            { value: "40000" },
+            { value: "60000" },
+          ]),
+      });
+
+      const service = new SponsorWalletService();
+
+      await expect(
+        service.getUtxoClaimGasFundingStatus(transfer)
+      ).resolves.toMatchObject({
+        funded: false,
+        status: "skipped",
+        balanceSats: 100_000,
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it("reserves a specific sponsor UTXO for claim gas funding", async () => {
@@ -1129,17 +1197,23 @@ describe("SponsorWalletService", () => {
       (global.fetch as jest.Mock<any>)
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
             Promise.resolve([
               { txid: "dust-utxo", vout: 2, value: "500" },
+              {
+                txid: "asset-utxo",
+                vout: 3,
+                value: "500000",
+                assetInfo: { assetGuid: "123456", value: "10000000" },
+              },
               { txid: "large-utxo", vout: 0, value: "2000000" },
               { txid: "small-utxo", vout: 1, value: "1000000" },
             ]),
@@ -1274,11 +1348,11 @@ describe("SponsorWalletService", () => {
       (global.fetch as jest.Mock<any>)
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -1348,11 +1422,11 @@ describe("SponsorWalletService", () => {
       (global.fetch as jest.Mock<any>)
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ balance: "0" }),
+          json: () => Promise.resolve([]),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -1414,7 +1488,7 @@ describe("SponsorWalletService", () => {
       });
       (global.fetch as jest.Mock<any>).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ balance: "0" }),
+        json: () => Promise.resolve([]),
       });
 
       const service = new SponsorWalletService();
@@ -1448,7 +1522,7 @@ describe("SponsorWalletService", () => {
       });
       (global.fetch as jest.Mock<any>).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ balance: "0" }),
+        json: () => Promise.resolve([]),
       });
 
       const service = new SponsorWalletService();

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -43,6 +43,7 @@ type SponsorUtxo = {
   txId?: string;
   vout: number;
   value: string | number;
+  assetInfo?: unknown;
 };
 
 type SponsorClaimGasResult = {
@@ -467,7 +468,7 @@ export class SponsorWalletService {
     }
 
     const targetAmountSats = this.getUtxoClaimGasAmountSats();
-    const addressBalanceSats = await this.getUtxoAddressBalanceSats(
+    const addressBalanceSats = await this.getMintCompatibleSysBalanceSats(
       transfer.utxoAddress
     );
 
@@ -482,7 +483,7 @@ export class SponsorWalletService {
     }
 
     if (transfer.utxoXpub) {
-      const xpubBalanceSats = await this.getUtxoXpubBalanceSats(
+      const xpubBalanceSats = await this.getMintCompatibleSysBalanceSats(
         transfer.utxoXpub
       );
 
@@ -995,34 +996,34 @@ export class SponsorWalletService {
     });
   }
 
-  private async getUtxoAddressBalanceSats(address: string): Promise<number> {
+  private async getMintCompatibleSysBalanceSats(
+    addressOrXpub: string
+  ): Promise<number> {
     const response = await fetch(
-      `${getUtxoBlockbookUrl()}/api/v2/address/${address}?details=basic`
+      `${getUtxoBlockbookUrl()}/api/v2/utxo/${encodeURIComponent(
+        addressOrXpub
+      )}`
     );
 
     if (!response.ok) {
-      throw new Error("Unable to fetch UTXO address balance");
+      throw new Error("Unable to fetch mint-compatible UTXOs");
     }
 
-    const data = (await response.json()) as { balance?: string };
-    const balance = Number.parseInt(data.balance ?? "0", 10);
-
-    return Number.isFinite(balance) ? balance : 0;
-  }
-
-  private async getUtxoXpubBalanceSats(xpub: string): Promise<number> {
-    const response = await fetch(
-      `${getUtxoBlockbookUrl()}/api/v2/xpub/${xpub}?details=basic`
-    );
-
-    if (!response.ok) {
-      throw new Error("Unable to fetch UTXO wallet balance");
+    const utxos = (await response.json()) as SponsorUtxo[];
+    if (!Array.isArray(utxos)) {
+      throw new Error("Invalid mint-compatible UTXO response");
     }
 
-    const data = (await response.json()) as { balance?: string };
-    const balance = Number.parseInt(data.balance ?? "0", 10);
+    return utxos.reduce((total, utxo) => {
+      // Canonical bridge mints cannot consume any asset-bearing input, even
+      // when that output contains enough native SYS to cover the fee.
+      if (utxo.assetInfo) {
+        return total;
+      }
 
-    return Number.isFinite(balance) ? balance : 0;
+      const value = Number(utxo.value);
+      return Number.isFinite(value) && value > 0 ? total + value : total;
+    }, 0);
   }
 
   private getUtxoClaimGasAmountSats() {
@@ -1087,7 +1088,7 @@ export class SponsorWalletService {
     const expiresAt = new Date(Date.now() + SPONSOR_RESERVATION_LEASE_MS);
 
     for (const utxo of utxos) {
-      if (Number(utxo.value) < minValueSats) {
+      if (utxo.assetInfo || Number(utxo.value) < minValueSats) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- calculate mint-compatible SYS from individual Blockbook UTXOs instead of aggregate wallet balance
- exclude asset-bearing outputs because canonical allocation mints cannot consume asset inputs
- exclude asset-bearing outputs from the sponsor wallet reservation path as well
- add regression coverage using the observed 29.89998650 SYS + 0.1 SYSX output shape

## Validation
- 18 Jest suites / 105 tests pass
- TypeScript passes
- lint passes (one pre-existing hook dependency warning)
- production build passes