### PR TITLE
chore: bump syscoinjs-lib to 1.0.273

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/lab": "^5.0.0-alpha.89",
     "@mui/material": "^5.7.0",
     "@mui/x-data-grid": "^5.11.1",
-    "@sidhujag/sysweb3-utils": "^1.1.277",
+    "@sidhujag/sysweb3-utils": "^1.1.278",
     "@sentry/nextjs": "^7.57.0",
     "axios": "^1.13.2",
     "bitcoin-proof": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-hook-form": "^7.31.3",
     "react-query": "^3.39.1",
     "satoshi-bitcoin": "^1.0.5",
-    "syscoinjs-lib": "^1.0.272",
+    "syscoinjs-lib": "^1.0.273",
     "web3": "1.10.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7523,10 +7523,10 @@ swarm-js@^0.1.40:
     tar "^4.0.2"
     xhr-request "^1.0.1"
 
-syscoinjs-lib@^1.0.272:
-  version "1.0.272"
-  resolved "https://registry.yarnpkg.com/syscoinjs-lib/-/syscoinjs-lib-1.0.272.tgz#b176b791bc7d4942ad36239da73130e36ce45cd7"
-  integrity sha512-dPYu9h4XfPD699aQ08xmt4UJMbBBOKiwJ8wHCsX4+jlFjOWTuQ/8LfqXrbxCDMI7OUaTWNIhJrAdU2DGpw/Lbg==
+syscoinjs-lib@^1.0.273:
+  version "1.0.273"
+  resolved "https://registry.yarnpkg.com/syscoinjs-lib/-/syscoinjs-lib-1.0.273.tgz#79f24635431f279831098340e50783992cfacfb6"
+  integrity sha512-qjFAaWb5v3pO7Fpm+m21dOVUDdl9P5wRHWMs5Es8ks1m7EGJDPDiofoka30Vg4EdMIKNwK2cHc4w6HXGSKPHgA==
   dependencies:
     "@bitcoinerlab/secp256k1" "^1.2.0"
     axios "^1.18.1"
@@ -7540,13 +7540,13 @@ syscoinjs-lib@^1.0.272:
     eth-object "https://github.com/syscoin/eth-object.git"
     eth-proof "^2.1.6"
     ethers "^6.17.0"
-    syscointx-js "^1.0.125"
+    syscointx-js "^1.0.127"
     varuint-bitcoin "^2.0.0"
 
-syscointx-js@^1.0.125:
-  version "1.0.125"
-  resolved "https://registry.yarnpkg.com/syscointx-js/-/syscointx-js-1.0.125.tgz#88d9883c45f03a01d5a625860ada93f87a778ec8"
-  integrity sha512-bAiZCRC1mpphtt8W7t86+ipFXOTn4VFjBbBr+TXcaE5CfP35vxTEaI2B8YaU6D7avHZkIS3kSlSpFSdsp91jMA==
+syscointx-js@^1.0.127:
+  version "1.0.127"
+  resolved "https://registry.yarnpkg.com/syscointx-js/-/syscointx-js-1.0.127.tgz#95c3822c0aa8f10eba1efa60f7ab348df31495f6"
+  integrity sha512-9bZ86RxcJvs7YdwiaPIqSgP2z0HD7n0E9mb0WG4deJRfbrRXLhMczmICvwJ/yIxlKx0SgF5rmF49rrX8mNKSEw==
   dependencies:
     "@bitcoinerlab/secp256k1" "^1.2.0"
     bitcoin-ops "^1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,10 +1448,10 @@
     eth-chains "^1.0.0"
     ethers "^6.17.0"
 
-"@sidhujag/sysweb3-utils@^1.1.277":
-  version "1.1.277"
-  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-utils/-/sysweb3-utils-1.1.277.tgz#b6542053db369c45eea42bb9c8e0aca61dfdf184"
-  integrity sha512-epkjCycSb6YZImYkRkcOE6/JO7qomoK7/IwiR5cONJGZ10bdD9QrSU/QmERBoTCJjRoZKyxIu/uplN11LufQFA==
+"@sidhujag/sysweb3-utils@^1.1.278":
+  version "1.1.278"
+  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-utils/-/sysweb3-utils-1.1.278.tgz#6d7ec231a9669813b8bf085940c0fa49562e2b1e"
+  integrity sha512-YYiDdWTIc+HY7WvDys+7GSLnwdrnYDtWfEMv5aA+0jh2CU8Z6L4nunw4CrIG0d/6Hk+6VO4qTBnrBB7G7HRGnQ==
   dependencies:
     "@sidhujag/sysweb3-network" "^1.0.109"
     bech32 "^2.0.0"


### PR DESCRIPTION
## Summary
- bump `syscoinjs-lib` from `^1.0.272` to `^1.0.273`
- resolve `syscointx-js 1.0.127` through the updated lockfile

This picks up the modern Blockbook asset-UTXO and exact-balance transaction fixes used by bridge UTXO flows.

## Verification
- frozen Yarn install passed
- 18 suites / 103 tests passed
- lint passed (1 pre-existing warning)
- production build passed