### PR TITLE
Refresh selected Pali account immediately

### DIFF
--- a/contexts/ConnectedWallet/NEVMProvider.tsx
+++ b/contexts/ConnectedWallet/NEVMProvider.tsx
@@ -149,7 +149,7 @@ const NEVMProvider: React.FC<NEVMProviderProps> = ({ children }) => {
     refetchOnWindowFocus: false, // Don't refetch on focus
   });
 
-  const balance = useQuery(["nevm", "balance"], {
+  const balance = useQuery(["nevm", "balance", account.data], {
     queryFn: () => {
       if (!isEnabled || !web3 || !account.data) {
         return;

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -192,6 +192,10 @@ export const PaliWalletV2Provider: React.FC<{
     if (bitcoinBased) {
       await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
     } else if (isEVMInjected.data) {
+      // A pre-update wallet event may already be fetching the previous EVM
+      // account. Cancel it so this invalidation must start a post-selection
+      // request instead of reusing the stale in-flight promise.
+      await queryClient.cancelQueries(["nevm", "account"]);
       await queryClient.invalidateQueries(["nevm"]);
     }
 

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -25,6 +25,7 @@ import {
   getPaliSyscoinSwitchRequest,
   readPaliBitcoinBasedState,
 } from "./utxo-network";
+import { createQueuedAccountChangeHandler } from "./account-change-queue";
 
 export interface ProviderState {
   xpub: string;
@@ -92,7 +93,6 @@ export const PaliWalletV2Provider: React.FC<{
 }> = ({ children }) => {
   const queryClient = useQueryClient();
   const { constants, refetch: refetchConstants } = useConstants();
-  const isProcessingAccountChange = useRef(false);
   const networkSwitchTarget = useRef<PaliWalletNetworkType | null>(null);
   const [isSwitchingToUtxo, setIsSwitchingToUtxo] = useState(false);
   
@@ -181,11 +181,28 @@ export const PaliWalletV2Provider: React.FC<{
   // Extract the account from the connection result
   const finalAccount = accountDetails.data || null;
 
-  const changeAccount = useCallback(() => {
-    return window.pali.request({
+  const changeAccount = useCallback(async () => {
+    const result = await window.pali.request({
       method: "wallet_changeAccount",
     });
-  }, []);
+
+    // Do not rely solely on wallet events: providers can emit their first
+    // account-change notification before eth_accounts reflects the selection.
+    const { data: bitcoinBased } = await isBitcoinBased.refetch();
+    if (bitcoinBased) {
+      await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
+    } else if (isEVMInjected.data) {
+      await queryClient.invalidateQueries(["nevm"]);
+    }
+
+    return result;
+  }, [
+    accountDetails,
+    isBitcoinBased,
+    isEVMInjected.data,
+    queryClient,
+    utxoAccount,
+  ]);
 
   const sysAddress = useMemo(
     () =>
@@ -397,15 +414,8 @@ export const PaliWalletV2Provider: React.FC<{
     };
 
     // Handle any account changes (both UTXO and EVM)
-    const handleAccountsChanged = async () => {
-      // Prevent recursive calls
-      if (isProcessingAccountChange.current) {
-        return;
-      }
-      
-      isProcessingAccountChange.current = true;
-      
-      try {
+    const handleAccountsChanged = createQueuedAccountChangeHandler(
+      async () => {
         const bitcoinBased = await refreshQueriesForActiveNetwork();
         if (
           bitcoinBased &&
@@ -413,13 +423,8 @@ export const PaliWalletV2Provider: React.FC<{
         ) {
           await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
         }
-      } finally {
-        // Reset after a short delay to allow legitimate subsequent changes.
-        setTimeout(() => {
-          isProcessingAccountChange.current = false;
-        }, 100);
       }
-    };
+    );
 
     // Listen for Pali notification events
     const handlePaliNotification = (event: any) => {

--- a/contexts/PaliWallet/account-change-queue.test.ts
+++ b/contexts/PaliWallet/account-change-queue.test.ts
@@ -1,0 +1,36 @@
+import { createQueuedAccountChangeHandler } from "./account-change-queue";
+
+describe("createQueuedAccountChangeHandler", () => {
+  it("runs a trailing refresh when a second notification overlaps the first", async () => {
+    let releaseFirstRefresh: () => void = () => undefined;
+    const firstRefresh = new Promise<void>((resolve) => {
+      releaseFirstRefresh = resolve;
+    });
+    const refresh = jest
+      .fn<Promise<void>, []>()
+      .mockImplementationOnce(() => firstRefresh)
+      .mockResolvedValueOnce(undefined);
+    const handleAccountChange = createQueuedAccountChangeHandler(refresh);
+
+    const firstChange = handleAccountChange();
+    await Promise.resolve();
+    await handleAccountChange();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    releaseFirstRefresh();
+    await firstChange;
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs a later non-overlapping notification normally", async () => {
+    const refresh = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    const handleAccountChange = createQueuedAccountChangeHandler(refresh);
+
+    await handleAccountChange();
+    await handleAccountChange();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contexts/PaliWallet/account-change-queue.ts
+++ b/contexts/PaliWallet/account-change-queue.ts
@@ -1,0 +1,30 @@
+export type AccountChangeRefresh = () => Promise<void>;
+
+/**
+ * Coalesce overlapping wallet notifications without dropping the last one.
+ * Wallets can notify before and after their injected provider state changes.
+ */
+export const createQueuedAccountChangeHandler = (
+  refresh: AccountChangeRefresh
+) => {
+  let isProcessing = false;
+  let hasPendingRefresh = false;
+
+  return async (): Promise<void> => {
+    if (isProcessing) {
+      hasPendingRefresh = true;
+      return;
+    }
+
+    isProcessing = true;
+
+    try {
+      do {
+        hasPendingRefresh = false;
+        await refresh();
+      } while (hasPendingRefresh);
+    } finally {
+      isProcessing = false;
+    }
+  };
+};


### PR DESCRIPTION
## What changed

- refresh the active wallet queries after `wallet_changeAccount` resolves
- queue a trailing refresh when overlapping Pali account notifications arrive
- add regression coverage for overlapping and sequential account changes

## Root cause

Pali can emit account notifications before and after its injected provider state updates. The bridge ignored every notification received while the first refresh was running and held that lock for another 100 ms, so the fresh notification could be discarded while the stale account remained cached until page reload.

## User impact

Selecting a different EVM or UTXO account now updates the bridge immediately without requiring a refresh.

## Validation

- `npm test -- --runInBand` — 19 suites, 113 tests passed
- `npm run lint` — passed (one pre-existing hook warning)
- `npm run build` — passed
