### PR TITLE
Apply Pali account event directly

### DIFF
--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -26,6 +26,7 @@ import {
   readPaliBitcoinBasedState,
 } from "./utxo-network";
 import { createQueuedAccountChangeHandler } from "./account-change-queue";
+import { getNevmAccountUpdateFromEvent } from "./account-event";
 
 export interface ProviderState {
   xpub: string;
@@ -182,6 +183,10 @@ export const PaliWalletV2Provider: React.FC<{
   const finalAccount = accountDetails.data || null;
 
   const changeAccount = useCallback(async () => {
+    const previousNevmAccount = queryClient.getQueryData<string | null>([
+      "nevm",
+      "account",
+    ]);
     const result = await window.pali.request({
       method: "wallet_changeAccount",
     });
@@ -192,11 +197,17 @@ export const PaliWalletV2Provider: React.FC<{
     if (bitcoinBased) {
       await Promise.all([utxoAccount.refetch(), accountDetails.refetch()]);
     } else if (isEVMInjected.data) {
-      // A pre-update wallet event may already be fetching the previous EVM
-      // account. Cancel it so this invalidation must start a post-selection
-      // request instead of reusing the stale in-flight promise.
-      await queryClient.cancelQueries(["nevm", "account"]);
-      await queryClient.invalidateQueries(["nevm"]);
+      const notifiedNevmAccount = queryClient.getQueryData<string | null>([
+        "nevm",
+        "account",
+      ]);
+
+      // The event path writes its authoritative address directly. Only fall
+      // back to discovery when no account update arrived with the popup.
+      if (notifiedNevmAccount === previousNevmAccount) {
+        await queryClient.cancelQueries(["nevm", "account"]);
+        await queryClient.invalidateQueries(["nevm"]);
+      }
     }
 
     return result;
@@ -430,13 +441,34 @@ export const PaliWalletV2Provider: React.FC<{
       }
     );
 
+    const applyNevmAccountEvent = (accounts: unknown) => {
+      const account = getNevmAccountUpdateFromEvent(
+        accounts,
+        isBitcoinBased.data === false ||
+          networkSwitchTarget.current === "ethereum"
+      );
+      if (account === undefined) {
+        return false;
+      }
+
+      queryClient.setQueryData(["nevm", "account"], account);
+      return true;
+    };
+
     // Listen for Pali notification events
     const handlePaliNotification = (event: any) => {
       try {
         const eventData = JSON.parse(event.detail);
         const data = eventData.data || eventData;
         
-        if (data?.method === 'pali_xpubChanged' || data?.method === 'pali_accountsChanged') {
+        if (data?.method === 'pali_xpubChanged') {
+          void handleAccountsChanged();
+        }
+
+        if (
+          data?.method === 'pali_accountsChanged' &&
+          !applyNevmAccountEvent(data?.params)
+        ) {
           void handleAccountsChanged();
         }
 
@@ -481,9 +513,10 @@ export const PaliWalletV2Provider: React.FC<{
       isBitcoinBased.isFetched &&
       !isBitcoinBased.data
     ) {
-      const handleEthAccountsChanged = () => {
-        // handleAccountsChanged will handle invalidating NEVM queries
-        void handleAccountsChanged();
+      const handleEthAccountsChanged = (accounts: unknown) => {
+        if (!applyNevmAccountEvent(accounts)) {
+          void handleAccountsChanged();
+        }
       };
       
       window.ethereum.on("accountsChanged", handleEthAccountsChanged);

--- a/contexts/PaliWallet/V2Provider.tsx
+++ b/contexts/PaliWallet/V2Provider.tsx
@@ -441,7 +441,7 @@ export const PaliWalletV2Provider: React.FC<{
       }
     );
 
-    const applyNevmAccountEvent = (accounts: unknown) => {
+    const applyNevmAccountEvent = async (accounts: unknown) => {
       const account = getNevmAccountUpdateFromEvent(
         accounts,
         isBitcoinBased.data === false ||
@@ -451,8 +451,18 @@ export const PaliWalletV2Provider: React.FC<{
         return false;
       }
 
+      // A popup fallback may already be fetching the previous account. Stop it
+      // before committing the authoritative event value so it cannot win the
+      // race and restore stale data afterward.
+      await queryClient.cancelQueries(["nevm", "account"]);
       queryClient.setQueryData(["nevm", "account"], account);
       return true;
+    };
+
+    const handleNevmAccountsChanged = async (accounts: unknown) => {
+      if (!(await applyNevmAccountEvent(accounts))) {
+        await handleAccountsChanged();
+      }
     };
 
     // Listen for Pali notification events
@@ -465,11 +475,8 @@ export const PaliWalletV2Provider: React.FC<{
           void handleAccountsChanged();
         }
 
-        if (
-          data?.method === 'pali_accountsChanged' &&
-          !applyNevmAccountEvent(data?.params)
-        ) {
-          void handleAccountsChanged();
+        if (data?.method === 'pali_accountsChanged') {
+          void handleNevmAccountsChanged(data?.params);
         }
 
         // React to network-type and chain changes instantly
@@ -514,9 +521,7 @@ export const PaliWalletV2Provider: React.FC<{
       !isBitcoinBased.data
     ) {
       const handleEthAccountsChanged = (accounts: unknown) => {
-        if (!applyNevmAccountEvent(accounts)) {
-          void handleAccountsChanged();
-        }
+        void handleNevmAccountsChanged(accounts);
       };
       
       window.ethereum.on("accountsChanged", handleEthAccountsChanged);

--- a/contexts/PaliWallet/account-event.test.ts
+++ b/contexts/PaliWallet/account-event.test.ts
@@ -1,0 +1,34 @@
+import { getNevmAccountUpdateFromEvent } from "./account-event";
+
+const EVM_ACCOUNT = "0x942db9399f51805f9a84664587210b7ce67e052e";
+
+describe("getNevmAccountUpdateFromEvent", () => {
+  it("uses the EVM address carried by accountsChanged", () => {
+    expect(getNevmAccountUpdateFromEvent([EVM_ACCOUNT], true)).toBe(
+      EVM_ACCOUNT
+    );
+  });
+
+  it("accepts an EVM address during a mode transition", () => {
+    expect(getNevmAccountUpdateFromEvent(EVM_ACCOUNT, false)).toBe(
+      EVM_ACCOUNT
+    );
+  });
+
+  it("ignores UTXO account payloads", () => {
+    expect(
+      getNevmAccountUpdateFromEvent(
+        ["tsys1quracwgy4t3fwlf3ugs25tgkc9qmtf95cmqqt96"],
+        false
+      )
+    ).toBeUndefined();
+  });
+
+  it("clears a disconnected EVM account", () => {
+    expect(getNevmAccountUpdateFromEvent([], true)).toBeNull();
+  });
+
+  it("does not treat an empty UTXO event as an EVM disconnect", () => {
+    expect(getNevmAccountUpdateFromEvent([], false)).toBeUndefined();
+  });
+});

--- a/contexts/PaliWallet/account-event.ts
+++ b/contexts/PaliWallet/account-event.ts
@@ -1,0 +1,25 @@
+import { isValidEthereumAddress } from "@sidhujag/sysweb3-utils";
+
+/**
+ * Return an authoritative EVM account update from an accountsChanged payload.
+ * Undefined means the payload belongs to the UTXO provider instead.
+ */
+export const getNevmAccountUpdateFromEvent = (
+  accounts: unknown,
+  isEvmMode: boolean
+): string | null | undefined => {
+  const accountList = Array.isArray(accounts)
+    ? accounts
+    : accounts === null || accounts === undefined
+    ? []
+    : [accounts];
+
+  if (accountList.length === 0) {
+    return isEvmMode ? null : undefined;
+  }
+
+  const account = accountList[0];
+  return typeof account === "string" && isValidEthereumAddress(account)
+    ? account
+    : undefined;
+};


### PR DESCRIPTION
## What changed

- apply the selected EVM address carried by Pali's `pali_accountsChanged` event directly to the bridge account query
- apply standard EIP-1193 `accountsChanged` payloads directly as well, preserving MetaMask compatibility
- keep account re-discovery only as a fallback when the event has no usable EVM address
- cancel in-flight account discovery before applying the authoritative event value

## Root cause

The previous fix re-fetched `eth_accounts` after Pali's account popup closed. Pali can emit the newly selected address before that provider query stops returning the previous address, so the bridge discarded the correct event value and cached the old account again.

## Impact

The selected EVM account updates immediately without requiring a page refresh. UTXO/SYS account events remain on the existing UTXO refresh path, and MetaMask remains supported through its standard `accountsChanged` event.

## Validation

- `npm test -- --runInBand` — 20 suites, 118 tests passed
- `npm run lint` — passed
- `npm run build` — production build passed
- `git diff --check` — passed