### PR TITLE
Keep wallet providers mounted across bridge navigation

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,25 +13,29 @@ const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps, router }: AppProps) {
   const isAdmin = router.pathname.includes("/admin");
-  if (router.pathname.includes("/bridge")) {
-    return (
-      <ThemeProvider theme={theme}>
-        <WelcomeModal />
-        <Component {...pageProps} />
-      </ThemeProvider>
-    );
-  }
+  const isBridge = router.pathname.includes("/bridge");
+
+  // Keep wallet/query providers mounted across client-side route changes.
+  // Replacing them while entering the bridge can strand requests and event
+  // listeners owned by the outgoing page, leaving the new buttons inert.
   return (
     <QueryClientProvider client={queryClient}>
       <PaliWalletV2Provider>
         <MetamaskProvider>
           <NEVMProvider>
-            <ConnectedWalletProvider>
+            {isBridge ? (
               <ThemeProvider theme={theme}>
-                {!isAdmin && <WelcomeModal />}
+                <WelcomeModal />
                 <Component {...pageProps} />
               </ThemeProvider>
-            </ConnectedWalletProvider>
+            ) : (
+              <ConnectedWalletProvider>
+                <ThemeProvider theme={theme}>
+                  {!isAdmin && <WelcomeModal />}
+                  <Component {...pageProps} />
+                </ThemeProvider>
+              </ConnectedWalletProvider>
+            )}
           </NEVMProvider>
         </MetamaskProvider>
       </PaliWalletV2Provider>

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -1,7 +1,4 @@
-import NEVMProvider from "@contexts/ConnectedWallet/NEVMProvider";
 import ConnectedWalletProvider from "@contexts/ConnectedWallet/Provider";
-import MetamaskProvider from "@contexts/Metamask/Provider";
-import { PaliWalletV2Provider } from "@contexts/PaliWallet/V2Provider";
 import {
   COMMON_STATUS,
   ITransfer,
@@ -30,7 +27,6 @@ import { Web3Provider } from "components/Bridge/context/Web";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
 import BridgeTransferSwitchTypeCard from "components/Bridge/TransferSwitchTypeCard";
@@ -73,8 +69,6 @@ const isDirectionRoute = (id: unknown): id is TransferType =>
 const BridgePage: NextPage = () => {
   const { query } = useRouter();
   const connectValidateDraft = useRef<Partial<ConnectValidateDraft>>({});
-  // Create a new QueryClient when the transfer ID changes to avoid stale data
-  const queryClient = useMemo(() => new QueryClient(), [query.id]);
 
   useEffect(() => {
     if (!isDirectionRoute(query.id)) {
@@ -103,63 +97,54 @@ const BridgePage: NextPage = () => {
   }, [query.id]);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <SyscoinProvider>
-        <Web3Provider>
-          <PaliWalletV2Provider>
-            <MetamaskProvider>
-              <NEVMProvider>
-                <ConnectedWalletProvider>
-                  <TransferContextProvider transfer={initialTransfer}>
-                    <Container sx={{ mt: 10, mb: 15 }}>
-                      <BlocktimeDisclaimer />
-                      <Typography variant="h5" fontWeight="bold">
-                        Bridge Your SYS
-                      </Typography>
-                      <Typography variant="caption" color="gray">
-                        Trustlessly transfer SYS back and forth between the
-                        Syscoin UTXO and Syscoin NEVM blockchains without
-                        middlemen!
-                      </Typography>
-                      <Box sx={{ my: 3 }}>
-                        <TransferTitle />
-                        <Button LinkComponent={NextLink} href="/transfers">
-                          <TableRowsIcon />
-                          View All Transfers
-                        </Button>
-                        <NewTransferButton />
-                      </Box>
-                      <BridgeStepper />
-                      <Box sx={{ mt: 3, mb: 2, width: "50%" }}>
-                        <BridgeTransferSwitchTypeCard />
-                      </Box>
-                      <Card
-                        sx={{
-                          mt: 1,
-                          display: "flex",
-                          flexDirection: "column",
-                          minWidth: "20rem",
-                          width: "50%",
-                        }}
-                      >
-                        <CardContent>
-                          <BridgeStepSwitch
-                            onConnectValidateDraftChange={
-                              handleConnectValidateDraftChange
-                            }
-                          />
-                          <BridgeSavingIndicator />
-                        </CardContent>
-                      </Card>
-                    </Container>
-                  </TransferContextProvider>
-                </ConnectedWalletProvider>
-              </NEVMProvider>
-            </MetamaskProvider>
-          </PaliWalletV2Provider>
-        </Web3Provider>
-      </SyscoinProvider>
-    </QueryClientProvider>
+    <SyscoinProvider>
+      <Web3Provider>
+        <ConnectedWalletProvider>
+          <TransferContextProvider transfer={initialTransfer}>
+            <Container sx={{ mt: 10, mb: 15 }}>
+              <BlocktimeDisclaimer />
+              <Typography variant="h5" fontWeight="bold">
+                Bridge Your SYS
+              </Typography>
+              <Typography variant="caption" color="gray">
+                Trustlessly transfer SYS back and forth between the Syscoin
+                UTXO and Syscoin NEVM blockchains without middlemen!
+              </Typography>
+              <Box sx={{ my: 3 }}>
+                <TransferTitle />
+                <Button LinkComponent={NextLink} href="/transfers">
+                  <TableRowsIcon />
+                  View All Transfers
+                </Button>
+                <NewTransferButton />
+              </Box>
+              <BridgeStepper />
+              <Box sx={{ mt: 3, mb: 2, width: "50%" }}>
+                <BridgeTransferSwitchTypeCard />
+              </Box>
+              <Card
+                sx={{
+                  mt: 1,
+                  display: "flex",
+                  flexDirection: "column",
+                  minWidth: "20rem",
+                  width: "50%",
+                }}
+              >
+                <CardContent>
+                  <BridgeStepSwitch
+                    onConnectValidateDraftChange={
+                      handleConnectValidateDraftChange
+                    }
+                  />
+                  <BridgeSavingIndicator />
+                </CardContent>
+              </Card>
+            </Container>
+          </TransferContextProvider>
+        </ConnectedWalletProvider>
+      </Web3Provider>
+    </SyscoinProvider>
   );
 };
 


### PR DESCRIPTION
## What changed

- keep the shared React Query, Pali, MetaMask, and NEVM providers mounted during Home → Bridge client navigation
- remove the bridge page's replacement QueryClient and duplicate wallet-provider stack
- retain bridge-only Syscoin, Web3, Connected Wallet, and Transfer providers inside the bridge page

## Root cause

Entering the bridge from Home tore down one wallet/query provider stack and immediately created another. Outstanding wallet requests and event listeners from the outgoing stack could overlap the new stack, leaving the bridge buttons inert. Loading the bridge directly avoided that lifecycle boundary, which is why refreshing the bridge page restored the buttons.

The bridge also replaced its QueryClient when the route ID changed without remounting every query consumer, allowing hooks and button callbacks to address different clients.

## Impact

Home → Bridge navigation now preserves wallet discovery, event listeners, and query ownership. Direct bridge loads and route transitions use the same provider lifecycle, while transfer data remains isolated by its transfer-ID query key.

## Validation

- `npm test -- --runInBand` — 20 suites, 118 tests passed
- `npm run lint` — clean, no warnings or errors
- `npm run build` — production build passed
- `git diff --check` — passed