### PR TITLE
Retry proof submission after the next NEVM block

### DIFF
--- a/api/routes/__tests__/signed-submit-proofs-tx.test.ts
+++ b/api/routes/__tests__/signed-submit-proofs-tx.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  PROOF_BLOCK_PENDING_CODE,
+  PROOF_BLOCK_RETRY_DELAY_MS,
+} from "utils/proof-submission";
+
+const mockGetBlock = jest.fn<any>();
+const mockGetBlockNumber = jest.fn<any>();
+const mockEncodeAbi = jest.fn(() => "0xrelay");
+const mockRelayTx = jest.fn(() => ({ encodeABI: mockEncodeAbi }));
+const mockSponsorTransaction = jest.fn<any>();
+const mockGetTransfer = jest.fn<any>();
+const mockGetCanonicalProof = jest.fn<any>();
+
+jest.mock("@constants", () => ({
+  RELAY_CONTRACT_ADDRESS: "0x1111111111111111111111111111111111111111",
+}));
+jest.mock("web3", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    eth: {
+      Contract: jest.fn().mockImplementation(() => ({
+        methods: { relayTx: mockRelayTx },
+      })),
+      getBlock: mockGetBlock,
+      getBlockNumber: mockGetBlockNumber,
+    },
+  })),
+}));
+jest.mock("api/services/sponsor-wallet", () => {
+  class SponsorshipInProgressError extends Error {}
+  class SponsorNonceRecoveryError extends Error {}
+
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      sponsorTransaction: mockSponsorTransaction,
+    })),
+    SponsorshipInProgressError,
+    SponsorNonceRecoveryError,
+  };
+});
+jest.mock("api/services/sponsor-proof", () => ({
+  getCanonicalProof: mockGetCanonicalProof,
+}));
+jest.mock("api/services/transfer", () => ({
+  TransferService: jest.fn().mockImplementation(() => ({
+    getTransfer: mockGetTransfer,
+  })),
+}));
+jest.mock("bitcoin-proof", () => ({
+  getProof: jest.fn(() => ({ sibling: ["sibling"] })),
+}));
+jest.mock("lib/mongodb", () => jest.fn());
+jest.mock("utils/api/cors", () => ({
+  applyApiCors: jest.fn(() => false),
+}));
+
+import handler from "pages/api/transfer/[id]/signed-submit-proofs-tx";
+
+const createResponse = () => {
+  const response = {
+    json: jest.fn(),
+    setHeader: jest.fn(),
+    status: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+const request = {
+  method: "GET",
+  query: { id: "transfer-1" },
+} as unknown as NextApiRequest;
+
+describe("signed proof submission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FOUNDATION_FUNDED = "true";
+    mockGetTransfer.mockResolvedValue({
+      id: "transfer-1",
+      version: "v2",
+      logs: [
+        {
+          status: "generate-proofs",
+          payload: { data: { nevm_blockhash: "proof-block-hash" } },
+        },
+      ],
+    });
+    mockGetCanonicalProof.mockResolvedValue({
+      sourceTxHash: "source-burn-hash",
+      proof: {
+        blockhash: "utxo-block-hash",
+        coinbase: "coinbase",
+        header: "header",
+        index: 1,
+        nevm_blockhash: "proof-block-hash",
+        siblings: ["sibling"],
+        transaction: "transaction",
+      },
+    });
+    mockGetBlock.mockResolvedValue({ number: 100 });
+    mockSponsorTransaction.mockResolvedValue({
+      status: "pending",
+      transaction: { hash: "0xsponsored", confirmedHash: "" },
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.FOUNDATION_FUNDED;
+  });
+
+  it("waits without reserving sponsorship when the proof block is the tip", async () => {
+    mockGetBlockNumber.mockResolvedValue(100);
+    const response = createResponse();
+
+    await handler(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.setHeader).toHaveBeenCalledWith("Retry-After", 10);
+    expect(response.json).toHaveBeenCalledWith({
+      code: PROOF_BLOCK_PENDING_CODE,
+      message: "Waiting for the next NEVM block before submitting the proof.",
+      retryAfterMs: PROOF_BLOCK_RETRY_DELAY_MS,
+    });
+    expect(mockRelayTx).not.toHaveBeenCalled();
+    expect(mockSponsorTransaction).not.toHaveBeenCalled();
+  });
+
+  it("submits once the proof block is historical", async () => {
+    mockGetBlockNumber.mockResolvedValue(101);
+    const response = createResponse();
+
+    await handler(request, response);
+
+    expect(mockSponsorTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSponsorTransaction).toHaveBeenCalledWith(
+      "transfer-1",
+      {
+        to: expect.any(String),
+        data: "0xrelay",
+        value: 0,
+      },
+      "submit-proofs",
+      "source-burn-hash"
+    );
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith({
+      status: "pending",
+      transaction: { hash: "0xsponsored", confirmedHash: "" },
+    });
+  });
+});

--- a/components/Bridge/Steps/SubmitProofs.tsx
+++ b/components/Bridge/Steps/SubmitProofs.tsx
@@ -46,7 +46,7 @@ const SubmitProofs: React.FC<Props> = ({ successStatus }) => {
     });
   };
 
-  const foundation = useSyscoinSubmitProofs(transfer, onSuccess);
+  const foundation = useSyscoinSubmitProofs(transfer);
   const self = useSubmitProof(transfer, spvProof);
 
   const foundationFundingAvailable = isEnabled("foundationFundingAvailable");
@@ -70,8 +70,8 @@ const SubmitProofs: React.FC<Props> = ({ successStatus }) => {
     return (
       <Alert severity="info">
         {foundationFundingAvailable
-          ? "Submitting proof..."
-          : "Confirm the transaction in your NEVM wallet."}
+          ? "Preparing proof submission..."
+          : "Preparing proof submission. Confirm it in your NEVM wallet when prompted."}
       </Alert>
     );
   }

--- a/components/Bridge/Steps/SubmitProofs.tsx
+++ b/components/Bridge/Steps/SubmitProofs.tsx
@@ -46,20 +46,23 @@ const SubmitProofs: React.FC<Props> = ({ successStatus }) => {
     });
   };
 
-  const foundation = useSyscoinSubmitProofs(transfer);
+  const foundation = useSyscoinSubmitProofs(transfer, onSuccess);
   const self = useSubmitProof(transfer, spvProof);
 
   const foundationFundingAvailable = isEnabled("foundationFundingAvailable");
 
   const {
-    mutate: submitProofs,
     isLoading: isSigning,
     isError: isSignError,
     error: signError,
   } = foundationFundingAvailable ? foundation : self;
 
   const sign = () => {
-    submitProofs(undefined, { onSuccess });
+    if (foundationFundingAvailable) {
+      foundation.mutate();
+      return;
+    }
+    self.mutate(undefined, { onSuccess });
   };
 
   if (!spvProof || !isSpvProof(spvProof)) {

--- a/components/Bridge/hooks/useSubmitProof.tsx
+++ b/components/Bridge/hooks/useSubmitProof.tsx
@@ -6,6 +6,11 @@ import { useWeb3 } from "../context/Web";
 
 import { ITransfer } from "@contexts/Transfer/types";
 import { useRelayContract } from "./useRelayContract";
+import {
+  assertProofBlockIsHistorical,
+  proofSubmissionRetryDelay,
+  shouldRetryPendingProof,
+} from "utils/proof-submission";
 
 
 export const isSpvProof = (data: unknown): data is SPVProof => {
@@ -20,6 +25,13 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
     }
+    if (nevmBlock.number === null) {
+      throw new Error("NEVM proof block has no block number");
+    }
+    assertProofBlockIsHistorical(
+      nevmBlock.number,
+      await web3.eth.getBlockNumber()
+    );
     if (!proof.coinbase) {
       throw new Error("The generated SPV proof is missing coinbase data");
     }
@@ -83,5 +95,8 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
           }
         });
     });
+  }, {
+    retry: shouldRetryPendingProof,
+    retryDelay: proofSubmissionRetryDelay,
   });
 };

--- a/components/Bridge/hooks/useSubmitProof.tsx
+++ b/components/Bridge/hooks/useSubmitProof.tsx
@@ -8,8 +8,7 @@ import { ITransfer } from "@contexts/Transfer/types";
 import { useRelayContract } from "./useRelayContract";
 import {
   assertProofBlockIsHistorical,
-  proofSubmissionRetryDelay,
-  shouldRetryPendingProof,
+  retryPendingProof,
 } from "utils/proof-submission";
 
 
@@ -25,12 +24,15 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
     }
-    if (nevmBlock.number === null) {
+    const proofBlockNumber = nevmBlock.number;
+    if (proofBlockNumber === null) {
       throw new Error("NEVM proof block has no block number");
     }
-    assertProofBlockIsHistorical(
-      nevmBlock.number,
-      await web3.eth.getBlockNumber()
+    await retryPendingProof(async () =>
+      assertProofBlockIsHistorical(
+        proofBlockNumber,
+        await web3.eth.getBlockNumber()
+      )
     );
     if (!proof.coinbase) {
       throw new Error("The generated SPV proof is missing coinbase data");
@@ -47,7 +49,7 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
     const syscoinBlockheader = `0x${proof.header}`;
 
     const method = relayContract.methods.relayTx(
-      nevmBlock.number,
+      proofBlockNumber,
       txBytes,
       txIndex,
       merkleProof.sibling,
@@ -95,8 +97,5 @@ export const useSubmitProof = (transfer: ITransfer, proof: SPVProof) => {
           }
         });
     });
-  }, {
-    retry: shouldRetryPendingProof,
-    retryDelay: proofSubmissionRetryDelay,
   });
 };

--- a/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
+++ b/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
@@ -19,7 +19,9 @@ const useSyscoinSubmitProofs = (
         transaction: { hash: string };
       } = await retryPendingProof(() =>
         fetch(
-          buildApiUrl(`/api/transfer/${transfer.id}/signed-submit-proofs-tx`)
+          buildApiUrl(
+            `/api/transfer/${encodeURIComponent(transfer.id)}/signed-submit-proofs-tx`
+          )
         ).then(async (res) => {
           if (res.ok) {
             return res.json();

--- a/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
+++ b/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
@@ -8,7 +8,10 @@ import {
   shouldRetryPendingProof,
 } from "utils/proof-submission";
 
-const useSyscoinSubmitProofs = (transfer: ITransfer) => {
+const useSyscoinSubmitProofs = (
+  transfer: ITransfer,
+  onSuccess: (hash: string) => void
+) => {
   return useMutation(
     ["syscoin-submit-proofs", transfer.id],
     async () => {
@@ -32,6 +35,7 @@ const useSyscoinSubmitProofs = (transfer: ITransfer) => {
       return sponsorWalletTransaction.transaction.hash;
     },
     {
+      onSuccess,
       retry: (failureCount, error) =>
         shouldRetryPendingProof(failureCount, error) || failureCount < 3,
       retryDelay: proofSubmissionRetryDelay,

--- a/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
+++ b/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
@@ -4,8 +4,8 @@ import { buildApiUrl } from "utils/api-base-url";
 import {
   ProofBlockPendingError,
   PROOF_BLOCK_PENDING_CODE,
-  proofSubmissionRetryDelay,
-  shouldRetryPendingProof,
+  isProofBlockPendingError,
+  retryPendingProof,
 } from "utils/proof-submission";
 
 const useSyscoinSubmitProofs = (
@@ -17,18 +17,20 @@ const useSyscoinSubmitProofs = (
     async () => {
       const sponsorWalletTransaction: {
         transaction: { hash: string };
-      } = await fetch(
-        buildApiUrl(`/api/transfer/${transfer.id}/signed-submit-proofs-tx`)
-      ).then(async (res) => {
-        if (res.ok) {
-          return res.json();
-        }
-        const error = await res.json();
-        if (error.code === PROOF_BLOCK_PENDING_CODE) {
-          throw new ProofBlockPendingError(error.message, error.retryAfterMs);
-        }
-        throw new Error(error.message ?? "Proof submission failed");
-      });
+      } = await retryPendingProof(() =>
+        fetch(
+          buildApiUrl(`/api/transfer/${transfer.id}/signed-submit-proofs-tx`)
+        ).then(async (res) => {
+          if (res.ok) {
+            return res.json();
+          }
+          const error = await res.json();
+          if (error.code === PROOF_BLOCK_PENDING_CODE) {
+            throw new ProofBlockPendingError(error.message, error.retryAfterMs);
+          }
+          throw new Error(error.message ?? "Proof submission failed");
+        })
+      );
 
       // The backend durably stores and broadcasts the signed transaction before
       // returning. The browser only observes the accepted transaction hash.
@@ -37,8 +39,7 @@ const useSyscoinSubmitProofs = (
     {
       onSuccess,
       retry: (failureCount, error) =>
-        shouldRetryPendingProof(failureCount, error) || failureCount < 3,
-      retryDelay: proofSubmissionRetryDelay,
+        !isProofBlockPendingError(error) && failureCount < 3,
     }
   );
 };

--- a/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
+++ b/components/Bridge/hooks/useSyscoinSubmitProofs.tsx
@@ -1,11 +1,14 @@
 import { ITransfer } from "@contexts/Transfer/types";
 import { useMutation } from "react-query";
 import { buildApiUrl } from "utils/api-base-url";
+import {
+  ProofBlockPendingError,
+  PROOF_BLOCK_PENDING_CODE,
+  proofSubmissionRetryDelay,
+  shouldRetryPendingProof,
+} from "utils/proof-submission";
 
-const useSyscoinSubmitProofs = (
-  transfer: ITransfer,
-  onSuccess: (hash: string) => void
-) => {
+const useSyscoinSubmitProofs = (transfer: ITransfer) => {
   return useMutation(
     ["syscoin-submit-proofs", transfer.id],
     async () => {
@@ -13,11 +16,15 @@ const useSyscoinSubmitProofs = (
         transaction: { hash: string };
       } = await fetch(
         buildApiUrl(`/api/transfer/${transfer.id}/signed-submit-proofs-tx`)
-      ).then((res) => {
+      ).then(async (res) => {
         if (res.ok) {
           return res.json();
         }
-        return res.json().then(({ message }) => Promise.reject(message));
+        const error = await res.json();
+        if (error.code === PROOF_BLOCK_PENDING_CODE) {
+          throw new ProofBlockPendingError(error.message, error.retryAfterMs);
+        }
+        throw new Error(error.message ?? "Proof submission failed");
       });
 
       // The backend durably stores and broadcasts the signed transaction before
@@ -25,10 +32,9 @@ const useSyscoinSubmitProofs = (
       return sponsorWalletTransaction.transaction.hash;
     },
     {
-      onSuccess: (data: string) => {
-        onSuccess(data);
-      },
-      retry: 3,
+      retry: (failureCount, error) =>
+        shouldRetryPendingProof(failureCount, error) || failureCount < 3,
+      retryDelay: proofSubmissionRetryDelay,
     }
   );
 };

--- a/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
+++ b/pages/api/transfer/[id]/signed-submit-proofs-tx.ts
@@ -12,6 +12,10 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import { SPVProof } from "syscoinjs-lib";
 import Web3 from "web3";
 import { applyApiCors } from "utils/api/cors";
+import {
+  assertProofBlockIsHistorical,
+  ProofBlockPendingError,
+} from "utils/proof-submission";
 
 const web3 = new Web3(process.env.NEVM_RPC_URL ?? "https://rpc.syscoin.org");
 
@@ -54,6 +58,13 @@ const handler: NextApiHandler = async (
     if (!nevmBlock) {
       throw new Error("NEVM block not found: " + proof.nevm_blockhash);
     }
+    if (nevmBlock.number === null) {
+      throw new Error("NEVM proof block has no block number");
+    }
+    assertProofBlockIsHistorical(
+      nevmBlock.number,
+      await web3.eth.getBlockNumber()
+    );
     if (!proof.coinbase) {
       throw new Error(
         "SPV proof missing coinbase (update syscoingetspvproof / blockbook)"
@@ -107,11 +118,20 @@ const handler: NextApiHandler = async (
       message = e.message;
     }
     const status =
+      e instanceof ProofBlockPendingError ||
       e instanceof SponsorshipInProgressError
         ? 409
         : e instanceof SponsorNonceRecoveryError
           ? 503
           : 500;
+    if (e instanceof ProofBlockPendingError) {
+      res.setHeader("Retry-After", e.retryAfterMs / 1_000);
+      return res.status(status).json({
+        code: e.code,
+        message,
+        retryAfterMs: e.retryAfterMs,
+      });
+    }
     res.status(status).json({ message });
   }
 };

--- a/utils/proof-submission.test.ts
+++ b/utils/proof-submission.test.ts
@@ -1,11 +1,9 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import {
   assertProofBlockIsHistorical,
-  MAX_PROOF_BLOCK_RETRIES,
   ProofBlockPendingError,
   PROOF_BLOCK_RETRY_DELAY_MS,
-  proofSubmissionRetryDelay,
-  shouldRetryPendingProof,
+  retryPendingProof,
 } from "./proof-submission";
 
 describe("proof submission block readiness", () => {
@@ -19,16 +17,41 @@ describe("proof submission block readiness", () => {
     );
   });
 
-  it("retries only the transient proof-block condition", () => {
-    const pending = new ProofBlockPendingError();
+  it("polls pending blocks within one operation", async () => {
+    const operation = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new ProofBlockPendingError())
+      .mockRejectedValueOnce(new ProofBlockPendingError())
+      .mockResolvedValueOnce("submitted");
+    const waitForRetry = jest
+      .fn<(delayMs: number) => Promise<void>>()
+      .mockResolvedValue();
 
-    expect(shouldRetryPendingProof(0, pending)).toBe(true);
-    expect(shouldRetryPendingProof(MAX_PROOF_BLOCK_RETRIES, pending)).toBe(
-      false
-    );
-    expect(shouldRetryPendingProof(0, new Error("permanent"))).toBe(false);
-    expect(proofSubmissionRetryDelay(0, pending)).toBe(
+    await expect(
+      retryPendingProof(operation, waitForRetry)
+    ).resolves.toBe("submitted");
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(waitForRetry).toHaveBeenNthCalledWith(
+      1,
       PROOF_BLOCK_RETRY_DELAY_MS
     );
+    expect(waitForRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a later non-pending failure to the caller", async () => {
+    const error = new Error("network unavailable");
+    const operation = jest
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new ProofBlockPendingError())
+      .mockRejectedValueOnce(error);
+    const waitForRetry = jest
+      .fn<(delayMs: number) => Promise<void>>()
+      .mockResolvedValue();
+
+    await expect(retryPendingProof(operation, waitForRetry)).rejects.toBe(
+      error
+    );
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(waitForRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/utils/proof-submission.test.ts
+++ b/utils/proof-submission.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  assertProofBlockIsHistorical,
+  MAX_PROOF_BLOCK_RETRIES,
+  ProofBlockPendingError,
+  PROOF_BLOCK_RETRY_DELAY_MS,
+  proofSubmissionRetryDelay,
+  shouldRetryPendingProof,
+} from "./proof-submission";
+
+describe("proof submission block readiness", () => {
+  it("accepts a proof only after its NEVM block becomes historical", () => {
+    expect(() => assertProofBlockIsHistorical(100, 101)).not.toThrow();
+    expect(() => assertProofBlockIsHistorical(100, 100)).toThrow(
+      ProofBlockPendingError
+    );
+    expect(() => assertProofBlockIsHistorical(101, 100)).toThrow(
+      ProofBlockPendingError
+    );
+  });
+
+  it("retries only the transient proof-block condition", () => {
+    const pending = new ProofBlockPendingError();
+
+    expect(shouldRetryPendingProof(0, pending)).toBe(true);
+    expect(shouldRetryPendingProof(MAX_PROOF_BLOCK_RETRIES, pending)).toBe(
+      false
+    );
+    expect(shouldRetryPendingProof(0, new Error("permanent"))).toBe(false);
+    expect(proofSubmissionRetryDelay(0, pending)).toBe(
+      PROOF_BLOCK_RETRY_DELAY_MS
+    );
+  });
+});

--- a/utils/proof-submission.ts
+++ b/utils/proof-submission.ts
@@ -35,16 +35,24 @@ export const isProofBlockPendingError = (
     "code" in error &&
     error.code === PROOF_BLOCK_PENDING_CODE);
 
-export const shouldRetryPendingProof = (
-  failureCount: number,
-  error: unknown
-) =>
-  isProofBlockPendingError(error) && failureCount < MAX_PROOF_BLOCK_RETRIES;
+const wait = (delayMs: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, delayMs));
 
-export const proofSubmissionRetryDelay = (
-  failureCount: number,
-  error: unknown
-) =>
-  isProofBlockPendingError(error) && "retryAfterMs" in error
-    ? error.retryAfterMs
-    : Math.min(1_000 * 2 ** failureCount, 30_000);
+export const retryPendingProof = async <T>(
+  operation: () => Promise<T>,
+  waitForRetry = wait
+): Promise<T> => {
+  for (let failureCount = 0; ; failureCount += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (
+        !isProofBlockPendingError(error) ||
+        failureCount >= MAX_PROOF_BLOCK_RETRIES
+      ) {
+        throw error;
+      }
+      await waitForRetry(error.retryAfterMs);
+    }
+  }
+};

--- a/utils/proof-submission.ts
+++ b/utils/proof-submission.ts
@@ -1,0 +1,50 @@
+export const PROOF_BLOCK_PENDING_CODE = "NEVM_PROOF_BLOCK_PENDING";
+export const PROOF_BLOCK_RETRY_DELAY_MS = 10_000;
+export const MAX_PROOF_BLOCK_RETRIES = 90;
+
+export class ProofBlockPendingError extends Error {
+  public readonly code = PROOF_BLOCK_PENDING_CODE;
+  public readonly retryAfterMs: number;
+
+  constructor(
+    message = "Waiting for the next NEVM block before submitting the proof.",
+    retryAfterMs = PROOF_BLOCK_RETRY_DELAY_MS
+  ) {
+    super(message);
+    this.name = "ProofBlockPendingError";
+    this.retryAfterMs = retryAfterMs;
+    Object.setPrototypeOf(this, ProofBlockPendingError.prototype);
+  }
+}
+
+export const assertProofBlockIsHistorical = (
+  proofBlockNumber: number,
+  latestBlockNumber: number
+) => {
+  if (proofBlockNumber >= latestBlockNumber) {
+    throw new ProofBlockPendingError();
+  }
+};
+
+export const isProofBlockPendingError = (
+  error: unknown
+): error is ProofBlockPendingError =>
+  error instanceof ProofBlockPendingError ||
+  (typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === PROOF_BLOCK_PENDING_CODE);
+
+export const shouldRetryPendingProof = (
+  failureCount: number,
+  error: unknown
+) =>
+  isProofBlockPendingError(error) && failureCount < MAX_PROOF_BLOCK_RETRIES;
+
+export const proofSubmissionRetryDelay = (
+  failureCount: number,
+  error: unknown
+) =>
+  isProofBlockPendingError(error) && "retryAfterMs" in error
+    ? error.retryAfterMs
+    : Math.min(1_000 * 2 ** failureCount, 30_000);


### PR DESCRIPTION
## Summary

- treat a proof whose paired NEVM block is still the current tip as transiently pending
- retry both sponsored and user-paid proof submission before gas estimation
- avoid sponsor nonce or transaction reservation while waiting
- preserve the persisted Submit Proofs stage across navigation and remove the duplicate success callback

## Root cause

`SYSBLOCKHASH` only returns hashes for historical NEVM blocks. Gas estimation performed while the proof block was still the current tip reverted even though the relay transaction would execute in the following block.

## Validation

- `yarn test --runInBand` (23 suites, 123 tests)
- `yarn lint`
- `yarn build`