### PR TITLE
Fix admin login and secure provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ The bridge UI is a ReactJS application that allows users to interact with the br
 
 Each step taken on the Bridge is stored in MongoDB. This allows the user to resume the process at any time.
 
+### Admin access
+
+Each deployment has a separate admin allowlist in its MongoDB database. Open
+`/admin/login`, connect the registered NEVM account on the network shown by the
+page, and sign the login message. The signature is free and does not submit a
+transaction.
+
+Provisioning an admin requires the deployment's `ADMIN_API_KEY`:
+
+```bash
+curl -X POST https://bridge.example/api/admin \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"address":"0x...","name":"Admin"}'
+```
+
+Admin addresses are normalized to lowercase. Never expose `ADMIN_API_KEY` in
+frontend configuration.
+
 ### Sponsored Transactions
 
 When `FOUNDATION_FUNDED=true`, the bridge sponsors destination-side transaction fees directly. Users still sign and pay the source-chain transaction.

--- a/api/routes/__tests__/admin-login.test.ts
+++ b/api/routes/__tests__/admin-login.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockDbConnect = jest.fn<any>();
+const mockFindOne = jest.fn<any>();
+const mockVerifySignature = jest.fn<any>();
+
+jest.mock("lib/mongodb", () => mockDbConnect);
+jest.mock("models/admin", () => ({
+  __esModule: true,
+  default: { findOne: mockFindOne },
+}));
+jest.mock("utils/api/verify-signature", () => ({
+  verifySignature: mockVerifySignature,
+}));
+jest.mock("utils/api/cors", () => ({
+  applyApiCors: jest.fn(() => false),
+}));
+jest.mock("lib/session", () => ({
+  withSessionRoute: (handler: unknown) => handler,
+}));
+
+import { NextApiRequest, NextApiResponse } from "next";
+import { adminLoginRequest } from "pages/api/admin/login";
+
+const checksumAddress = "0x95E7F1A98F46541787344032550B8DC633CC5867";
+const normalizedAddress = checksumAddress.toLowerCase();
+
+const createResponse = () => {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+const createRequest = () => {
+  const save = jest.fn<any>().mockResolvedValue(undefined);
+  const request = {
+    method: "POST",
+    body: { address: checksumAddress, signedMessage: "0xsigned" },
+    headers: {},
+    session: { save },
+  } as unknown as NextApiRequest;
+  return { request, save };
+};
+
+describe("admin login", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDbConnect.mockResolvedValue(undefined);
+    mockVerifySignature.mockReturnValue(true);
+  });
+
+  it("normalizes a checksum-cased wallet before finding the admin", async () => {
+    mockFindOne.mockResolvedValue({
+      address: normalizedAddress,
+      name: "function0x",
+    });
+    const { request, save } = createRequest();
+    const response = createResponse();
+
+    await adminLoginRequest(request, response);
+
+    expect(mockVerifySignature).toHaveBeenCalledWith(
+      "Login to Syscoin Bridge Admin",
+      "0xsigned",
+      normalizedAddress
+    );
+    expect(mockFindOne).toHaveBeenCalledWith({ address: normalizedAddress });
+    expect(request.session.user).toEqual({
+      address: normalizedAddress,
+      name: "function0x",
+    });
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(response.status).toHaveBeenCalledWith(200);
+  });
+
+  it("returns an explicit error for an unregistered wallet", async () => {
+    mockFindOne.mockResolvedValue(null);
+    const { request, save } = createRequest();
+    const response = createResponse();
+
+    await adminLoginRequest(request, response);
+
+    expect(save).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({
+      success: false,
+      message: "This wallet is not registered as an administrator",
+    });
+  });
+
+  it("rejects malformed signatures without throwing", async () => {
+    mockVerifySignature.mockImplementation(() => {
+      throw new Error("bad signature encoding");
+    });
+    const { request } = createRequest();
+    const response = createResponse();
+
+    await adminLoginRequest(request, response);
+
+    expect(mockFindOne).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(response.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Wallet signature is invalid",
+    });
+  });
+});

--- a/api/routes/__tests__/admin-route.test.ts
+++ b/api/routes/__tests__/admin-route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockCreateAdmin = jest.fn<any>();
+
+jest.mock("api/services/admin", () => ({
+  AdminService: jest.fn().mockImplementation(() => ({
+    createAdmin: mockCreateAdmin,
+    getAdmin: jest.fn(),
+  })),
+}));
+jest.mock("lib/mongodb", () => jest.fn());
+jest.mock("utils/api/cors", () => ({
+  applyApiCors: jest.fn(() => false),
+}));
+
+import { NextApiRequest, NextApiResponse } from "next";
+import adminHandler from "pages/api/admin";
+
+const createResponse = () => {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as NextApiResponse & typeof response;
+};
+
+const createRequest = (authorization?: string) =>
+  ({
+    method: "POST",
+    headers: authorization ? { authorization } : {},
+    body: {
+      address: "0x95E7F1A98F46541787344032550B8DC633CC5867",
+      name: "function0x",
+    },
+  } as unknown as NextApiRequest);
+
+describe("admin provisioning route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_API_KEY = "provisioning-secret";
+    mockCreateAdmin.mockResolvedValue({ address: "0xadmin" });
+  });
+
+  it("rejects unauthenticated admin creation", async () => {
+    const response = createResponse();
+
+    await adminHandler(createRequest(), response);
+
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(mockCreateAdmin).not.toHaveBeenCalled();
+  });
+
+  it("allows admin creation with the configured API key", async () => {
+    const response = createResponse();
+
+    await adminHandler(
+      createRequest("Bearer provisioning-secret"),
+      response
+    );
+
+    expect(mockCreateAdmin).toHaveBeenCalledWith(
+      "0x95E7F1A98F46541787344032550B8DC633CC5867",
+      "function0x"
+    );
+    expect(response.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/api/services/admin.ts
+++ b/api/services/admin.ts
@@ -1,13 +1,21 @@
 import Admin, { IAdmin } from "../../models/admin";
+
+export const normalizeAdminAddress = (address: string) =>
+  address.trim().toLowerCase();
+
 export class AdminService {
   public async isAdmin(address: string): Promise<boolean> {
-    const admin = await Admin.exists({ address }).exec();
+    const admin = await Admin.exists({
+      address: normalizeAdminAddress(address),
+    }).exec();
 
     return admin !== null;
   }
 
   public async getAdmin(address: string): Promise<IAdmin | null> {
-    const admin = await Admin.findOne({ address }).exec();
+    const admin = await Admin.findOne({
+      address: normalizeAdminAddress(address),
+    }).exec();
     if (!admin) {
       return null;
     }
@@ -16,14 +24,15 @@ export class AdminService {
   }
 
   public async createAdmin(address: string, name: string): Promise<IAdmin> {
+    const normalizedAddress = normalizeAdminAddress(address);
     // Check if address is already an admin
-    const isAdmin = await this.isAdmin(address);
+    const isAdmin = await this.isAdmin(normalizedAddress);
 
     if (isAdmin) {
       throw new Error("Address is already an admin");
     }
 
-    const admin = new Admin({ address, name });
+    const admin = new Admin({ address: normalizedAddress, name: name.trim() });
 
     return await admin.save();
   }

--- a/components/Admin/ConnectAdmin.tsx
+++ b/components/Admin/ConnectAdmin.tsx
@@ -1,22 +1,41 @@
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
-import { Button } from "@mui/material";
+import { Button, Stack } from "@mui/material";
+import { useConstants } from "@contexts/useConstants";
 
 const ConnectAdmin = () => {
-  const { account, connect } = useNEVM();
+  const { account, connect, isWrongChain, switchToMainnet } = useNEVM();
   const { isBitcoinBased, isEVMInjected, switchTo } = usePaliWalletV2();
+  const { constants } = useConstants();
 
   const isConnected = Boolean(account);
+  const networkName = constants?.isTestnet
+    ? "Tanenbaum NEVM"
+    : "Syscoin NEVM Mainnet";
 
   return (
-    <>
+    <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
       {!isConnected && !isBitcoinBased && (
-        <Button onClick={connect}>Connect</Button>
+        <Button variant="contained" onClick={connect}>
+          Connect NEVM wallet
+        </Button>
       )}
       {isBitcoinBased && isEVMInjected && (
-        <Button onClick={() => switchTo("ethereum")}>Switch to NEVM</Button>
+        <Button variant="contained" onClick={() => switchTo("ethereum")}>
+          Switch Pali to NEVM
+        </Button>
       )}
-    </>
+      {isConnected && isWrongChain && (
+        <Button variant="contained" onClick={switchToMainnet}>
+          Switch to {networkName}
+        </Button>
+      )}
+      {isConnected && (
+        <Button variant="outlined" onClick={connect}>
+          Use another wallet
+        </Button>
+      )}
+    </Stack>
   );
 };
 

--- a/components/Admin/ConnectAdmin.tsx
+++ b/components/Admin/ConnectAdmin.tsx
@@ -5,7 +5,8 @@ import { useConstants } from "@contexts/useConstants";
 
 const ConnectAdmin = () => {
   const { account, connect, isWrongChain, switchToMainnet } = useNEVM();
-  const { isBitcoinBased, isEVMInjected, switchTo } = usePaliWalletV2();
+  const { changeAccount, isBitcoinBased, isEVMInjected, switchTo } =
+    usePaliWalletV2();
   const { constants } = useConstants();
 
   const isConnected = Boolean(account);
@@ -31,7 +32,10 @@ const ConnectAdmin = () => {
         </Button>
       )}
       {isConnected && (
-        <Button variant="outlined" onClick={connect}>
+        <Button
+          variant="outlined"
+          onClick={isEVMInjected ? changeAccount : connect}
+        >
           Use another wallet
         </Button>
       )}

--- a/models/admin.ts
+++ b/models/admin.ts
@@ -12,6 +12,8 @@ const AdminSchema = new mongoose.Schema<IAdmin>({
     type: String,
     required: true,
     unique: true,
+    lowercase: true,
+    trim: true,
   },
   name: {
     type: String,

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,57 +1,154 @@
 import { ADMIN_LOGIN_MESSAGE } from "@constants";
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
-import { Button, Container } from "@mui/material";
+import { useConstants } from "@contexts/useConstants";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
 import ConnectAdmin from "components/Admin/ConnectAdmin";
 import { GetServerSideProps, NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useState } from "react";
 
 type Props = {
   loginMessage: string;
 };
 
 export const AdminLoginPage: NextPage<Props> = ({ loginMessage }) => {
-  const { account, signMessage } = useNEVM();
+  const {
+    account,
+    chainId,
+    expectedChainId,
+    isExpectedChain,
+    isWrongChain,
+    signMessage,
+  } = useNEVM();
+  const { constants } = useConstants();
   const { replace } = useRouter();
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [error, setError] = useState<string>();
+  const networkName = constants?.isTestnet
+    ? "Tanenbaum NEVM"
+    : "Syscoin NEVM Mainnet";
 
-  const onLogin = () => {
-    signMessage(loginMessage)
-      .then((signedMessage) =>
-        fetch("/api/admin/login", {
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ address: account, signedMessage }),
-          method: "POST",
-          credentials: "include",
-        })
-      )
-      .then((res) => {
-        if (res.status === 200) {
-          replace("/admin");
-        }
-      });
-  };
-
-  useEffect(() => {
-    if (account) {
-      console.log({ account });
+  const onLogin = async () => {
+    if (!account) {
+      setError("Connect the NEVM wallet registered for this admin portal.");
+      return;
     }
-  }, [account]);
+    if (!isExpectedChain) {
+      setError(`Switch your wallet to ${networkName} before signing in.`);
+      return;
+    }
+
+    setError(undefined);
+    setIsLoggingIn(true);
+    try {
+      const adminResponse = await fetch(
+        `/api/admin?address=${encodeURIComponent(account)}`
+      );
+      if (adminResponse.status === 404) {
+        throw new Error(
+          `This wallet is not registered for the ${networkName} admin portal.`
+        );
+      }
+      if (!adminResponse.ok) {
+        throw new Error("Unable to verify administrator access.");
+      }
+
+      const signedMessage = await signMessage(loginMessage);
+      const response = await fetch("/api/admin/login", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: account, signedMessage }),
+        method: "POST",
+        credentials: "include",
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(body?.message || "Administrator sign-in failed.");
+      }
+      await replace("/admin");
+    } catch (loginError) {
+      if ((loginError as { code?: number })?.code === 4001) {
+        setError("The wallet signature request was cancelled.");
+      } else {
+        setError(
+          loginError instanceof Error
+            ? loginError.message
+            : "Administrator sign-in failed."
+        );
+      }
+    } finally {
+      setIsLoggingIn(false);
+    }
+  };
 
   return (
     <Container
+      maxWidth="sm"
       sx={{
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
-        height: "100vh",
+        minHeight: "100vh",
+        py: 4,
       }}
     >
-      <ConnectAdmin />
-      {account && (
-        <Button variant="contained" onClick={onLogin}>
-          Login as Admin: {account}
-        </Button>
-      )}
+      <Paper elevation={3} sx={{ width: "100%", p: { xs: 3, sm: 4 } }}>
+        <Stack spacing={3}>
+          <Box>
+            <Typography component="h1" variant="h4" gutterBottom>
+              Bridge administration
+            </Typography>
+            <Typography color="text.secondary">
+              Connect a registered administrator wallet on {networkName}, then
+              sign the login message. Signing is free and does not submit a
+              transaction.
+            </Typography>
+          </Box>
+
+          {account && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Connected wallet
+              </Typography>
+              <Typography sx={{ overflowWrap: "anywhere" }}>
+                {account}
+              </Typography>
+            </Box>
+          )}
+
+          {isWrongChain && (
+            <Alert severity="warning">
+              Wrong network. Connected to chain {chainId}; this portal requires
+              {` ${expectedChainId}`}.
+            </Alert>
+          )}
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <ConnectAdmin />
+
+          {account && (
+            <Button
+              size="large"
+              variant="contained"
+              disabled={isLoggingIn || !isExpectedChain}
+              onClick={onLogin}
+              startIcon={
+                isLoggingIn ? <CircularProgress size={18} /> : undefined
+              }
+            >
+              {isLoggingIn ? "Signing in…" : "Sign in"}
+            </Button>
+          )}
+        </Stack>
+      </Paper>
     </Container>
   );
 };

--- a/pages/api/admin/index.ts
+++ b/pages/api/admin/index.ts
@@ -2,6 +2,7 @@ import { AdminService } from "api/services/admin";
 import dbConnect from "lib/mongodb";
 import { NextApiHandler } from "next";
 import { applyApiCors } from "utils/api/cors";
+import adminGuard from "utils/api/admin-guard";
 
 const adminService = new AdminService();
 
@@ -14,7 +15,7 @@ const isValidBody = (body: any): body is ICreateAdminBody => {
   return typeof body.address === "string" && typeof body.name === "string";
 };
 
-const handler: NextApiHandler = async (req, res) => {
+export const adminRequest: NextApiHandler = async (req, res) => {
   if (applyApiCors(req, res)) {
     return;
   }
@@ -26,7 +27,7 @@ const handler: NextApiHandler = async (req, res) => {
       return res.status(400).json({ message: "Missing address" });
     }
     try {
-      const admin = await adminService.getAdmin(address.toLocaleLowerCase());
+      const admin = await adminService.getAdmin(address);
       if (admin === null) {
         return res.status(404).json({ message: "Admin not found" });
       }
@@ -46,7 +47,7 @@ const handler: NextApiHandler = async (req, res) => {
       return res.status(400).json({ message: "Missing address or name" });
     }
     return adminService
-      .createAdmin(address.toLocaleLowerCase(), name)
+      .createAdmin(address, name)
       .then((admin) => {
         return res.status(200).json(admin);
       })
@@ -56,6 +57,15 @@ const handler: NextApiHandler = async (req, res) => {
   }
 
   return res.status(400).json({ message: "Invalid method" });
+};
+
+const guardedAdminRequest = adminGuard(adminRequest);
+
+const handler: NextApiHandler = (req, res) => {
+  if (req.method === "POST") {
+    return guardedAdminRequest(req, res);
+  }
+  return adminRequest(req, res);
 };
 
 export default handler;

--- a/pages/api/admin/login.ts
+++ b/pages/api/admin/login.ts
@@ -5,50 +5,61 @@ import dbConnect from "lib/mongodb";
 import AdminModel from "models/admin";
 import { verifySignature } from "utils/api/verify-signature";
 import { applyApiCors } from "utils/api/cors";
+import { normalizeAdminAddress } from "api/services/admin";
 
-const AdminLoginApiRoute: NextApiHandler = withSessionRoute(
-  async (req, res) => {
-    if (applyApiCors(req, res, { allowCredentials: true })) {
-      return;
-    }
+export const adminLoginRequest: NextApiHandler = async (req, res) => {
+  if (applyApiCors(req, res, { allowCredentials: true })) {
+    return;
+  }
 
-    if (req.method !== "POST") {
-      return res.status(405).json({ message: "Method not allowed" });
-    }
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
 
-    const { address, signedMessage } = req.body;
+  const { address, signedMessage } = req.body ?? {};
+  if (typeof address !== "string" || typeof signedMessage !== "string") {
+    return res.status(400).json({
+      success: false,
+      message: "Wallet address and signature are required",
+    });
+  }
 
-    const isVerified = verifySignature(
+  const normalizedAddress = normalizeAdminAddress(address);
+  let isVerified = false;
+  try {
+    isVerified = verifySignature(
       ADMIN_LOGIN_MESSAGE,
       signedMessage,
-      address
+      normalizedAddress
     );
-
-    if (!isVerified) {
-      return res
-        .status(401)
-        .json({ success: false, message: "signature invalid" });
-    }
-
-    await dbConnect();
-
-    const adminUser = await AdminModel.findOne({ address });
-
-    if (!adminUser) {
-      return res.status(401).json({
-        success: false,
-        message: `address ${address} is not registered as admin`,
-      });
-    }
-
-    req.session.user = {
-      address: adminUser.address,
-      name: adminUser.name,
-    };
-
-    await req.session.save();
-    return res.status(200).json({ success: true });
+  } catch {
+    isVerified = false;
   }
-);
 
-export default AdminLoginApiRoute;
+  if (!isVerified) {
+    return res
+      .status(401)
+      .json({ success: false, message: "Wallet signature is invalid" });
+  }
+
+  await dbConnect();
+
+  const adminUser = await AdminModel.findOne({ address: normalizedAddress });
+
+  if (!adminUser) {
+    return res.status(403).json({
+      success: false,
+      message: "This wallet is not registered as an administrator",
+    });
+  }
+
+  req.session.user = {
+    address: normalizeAdminAddress(adminUser.address),
+    name: adminUser.name,
+  };
+
+  await req.session.save();
+  return res.status(200).json({ success: true });
+};
+
+export default withSessionRoute(adminLoginRequest);

--- a/utils/api/admin-guard.ts
+++ b/utils/api/admin-guard.ts
@@ -1,8 +1,6 @@
 import { NextApiHandler } from "next";
 import { applyApiCors } from "utils/api/cors";
 
-const apiKey = process.env.ADMIN_API_KEY;
-
 const adminGuard = (handler: NextApiHandler) => {
   const checkHandler: NextApiHandler = (req, res) => {
     if (applyApiCors(req, res)) {
@@ -10,6 +8,7 @@ const adminGuard = (handler: NextApiHandler) => {
     }
 
     const { authorization } = req.headers;
+    const apiKey = process.env.ADMIN_API_KEY;
     if (
       !authorization ||
       apiKey === undefined ||


### PR DESCRIPTION
## What changed

- replace the inert admin-login button with a clear wallet, network, signing, loading, and error flow
- normalize administrator addresses consistently for creation, lookup, signature verification, and sessions
- require `ADMIN_API_KEY` for administrator provisioning while keeping the login preflight lookup available
- document the per-deployment admin allowlist and provisioning process
- add regression coverage for checksum-cased login, invalid/unregistered login, and protected provisioning

## Why

Pali exposes a checksum-cased NEVM address, while administrator records are stored lowercase. The login route performed an exact-case lookup and the page ignored failed API responses, making a registered administrator appear unable to log in with no explanation. The provisioning endpoint was also reachable without the intended API-key guard.

## Impact

Registered administrators can sign in reliably from Pali on the correct deployment network. The page now explains that login uses a free message signature and provides actionable errors and network controls. Admin creation is restricted to callers holding the deployment's server-side API key.

## Validation

- full test suite: 25 suites, 129 tests passed
- lint passed
- production build passed
- admin login page visually inspected at desktop and mobile widths
