### PR TITLE
Fix admin dashboard rendering

### DIFF
--- a/components/Admin/Transfer/Filters.tsx
+++ b/components/Admin/Transfer/Filters.tsx
@@ -1,10 +1,17 @@
 import { Box, Button, TextField } from "@mui/material";
-import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
 const AdminTransferFilters: React.FC = () => {
-  const { get } = useSearchParams();
-  const [id, setId] = useState(get("id"));
+  const { isReady, query } = useRouter();
+  const queryId = Array.isArray(query.id) ? query.id[0] : query.id;
+  const [id, setId] = useState(queryId ?? "");
+
+  useEffect(() => {
+    if (isReady) {
+      setId(queryId ?? "");
+    }
+  }, [isReady, queryId]);
 
   return (
     <Box component="form" sx={{ mt: 2, alignItems: "center", display: "flex" }}>

--- a/components/WelcomeModal.tsx
+++ b/components/WelcomeModal.tsx
@@ -58,9 +58,13 @@ const WelcomeModal = () => {
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: 500,
+          width: { xs: "calc(100% - 32px)", sm: 500 },
+          maxHeight: "calc(100vh - 32px)",
+          overflowY: "auto",
           bgcolor: "background.paper",
-          border: "2px solid #000",
+          color: "text.primary",
+          border: "2px solid",
+          borderColor: "primary.main",
           boxShadow: 24,
           borderRadius: 4,
           p: 4,
@@ -70,7 +74,7 @@ const WelcomeModal = () => {
         <List dense sx={{ my: 2 }}>
           {terms.map((term, i) => (
             <ListItem key={i}>
-              <ListItemIcon>
+              <ListItemIcon sx={{ color: "text.primary" }}>
                 <Check />
               </ListItemIcon>
               <Typography variant="body1">{term}</Typography>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,11 +8,12 @@ import MetamaskProvider from "../contexts/Metamask/Provider";
 import "../styles/globals.css";
 import NEVMProvider from "@contexts/ConnectedWallet/NEVMProvider";
 import WelcomeModal from "components/WelcomeModal";
+import { isAdminRoute } from "utils/app-route";
 
 const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps, router }: AppProps) {
-  const isAdmin = router.pathname.includes("/admin");
+  const isAdmin = isAdminRoute(router.pathname, router.asPath);
   const isBridge = router.pathname.includes("/bridge");
 
   // Keep wallet/query providers mounted across client-side route changes.

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps, NextPage } from "next";
 import { SessionUser, withSessionSsr } from "lib/session";
 import { Box, Button, Container, Typography } from "@mui/material";
-import { useRouter } from "next/navigation";
+import { useRouter } from "next/router";
 import AdminTransferList from "components/Admin/Transfer/List";
 import { ITransfer } from "@contexts/Transfer/types";
 import AdminTransferFilters from "components/Admin/Transfer/Filters";
@@ -13,15 +13,22 @@ type Props = {
   pageSize: number;
 };
 
-const AdminPage: NextPage<Props> = ({ user, transfers, total, pageSize }) => {
-  const { refresh, push } = useRouter();
+export const AdminPage: NextPage<Props> = ({
+  user,
+  transfers,
+  total,
+  pageSize,
+}) => {
+  const { push, replace } = useRouter();
 
-  const onLogout = () => {
-    fetch("/api/admin/logout", {
+  const onLogout = async () => {
+    const response = await fetch("/api/admin/logout", {
       credentials: "include",
-    }).then((res) => {
-      res.ok && refresh();
     });
+
+    if (response.ok) {
+      await replace("/admin/login");
+    }
   };
 
   const onPageChange = (page: number) => {

--- a/utils/admin-pages-router.test.ts
+++ b/utils/admin-pages-router.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("admin Pages Router components", () => {
+  it.each([
+    "pages/admin/index.tsx",
+    "components/Admin/Transfer/Filters.tsx",
+  ])("does not import App Router hooks in %s", (relativePath) => {
+    const source = readFileSync(join(process.cwd(), relativePath), "utf8");
+
+    expect(source).toContain('from "next/router"');
+    expect(source).not.toContain('from "next/navigation"');
+  });
+});

--- a/utils/app-route.test.ts
+++ b/utils/app-route.test.ts
@@ -1,0 +1,14 @@
+import { isAdminRoute } from "./app-route";
+
+describe("isAdminRoute", () => {
+  it.each([
+    ["/admin", "/admin", true],
+    ["/admin/login", "/admin/login", true],
+    ["/_error", "/admin", true],
+    ["/_error", "/admin?filter=failed", true],
+    ["/_error", "/bridge/transfer-id", false],
+    ["/administrator", "/administrator", false],
+  ])("classifies pathname %s and asPath %s", (pathname, asPath, expected) => {
+    expect(isAdminRoute(pathname, asPath)).toBe(expected);
+  });
+});

--- a/utils/app-route.ts
+++ b/utils/app-route.ts
@@ -1,0 +1,10 @@
+const normalizeRoute = (route?: string) =>
+  (route || "").split(/[?#]/, 1)[0].replace(/\/+$/, "") || "/";
+
+const isWithinRoute = (route: string, root: string) =>
+  route === root || route.startsWith(`${root}/`);
+
+export const isAdminRoute = (pathname?: string, asPath?: string) =>
+  [pathname, asPath]
+    .map(normalizeRoute)
+    .some((route) => isWithinRoute(route, "/admin"));


### PR DESCRIPTION
## What changed

- use Pages Router hooks throughout the admin dashboard and transfer filters
- redirect directly to the admin login page after logout
- preserve admin-route detection when Next.js renders an error page for `/admin`
- keep the bridge terms modal out of every admin route, including error states
- set explicit modal foreground colors and responsive scrolling for reliable contrast
- add regression coverage for admin route classification and router imports

## Root cause

The authenticated admin page imported `useRouter` and `useSearchParams` from `next/navigation` even though the application uses the Pages Router. Server rendering therefore threw `invariant expected app router to be mounted`, producing HTTP 500. Next then rendered `/_error`; because the app checked only `router.pathname`, the global bridge terms modal appeared over that admin error page.

## Impact

Administrators can open the transfer dashboard after signing in, filter transfers, paginate, and log out normally. Bridge terms remain available to bridge users but never interrupt administration. The terms modal also has explicit dark-on-light contrast and fits smaller viewports.

## Validation

- reproduced production behavior: authenticated API and proxy returned HTTP 200 while `/admin` returned HTTP 500
- focused regression tests passed
- full suite passed: 27 suites, 137 tests
- lint passed
- production build passed
- authenticated local `/admin?id=transfer-123` SSR returned HTTP 200 and preserved the filter value
- modal computed styles verified as `rgb(26, 26, 40)` text on `rgb(255, 255, 255)` background
