### PR TITLE
Fix admin SSR authentication on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Frontend/API routing
 NEXT_PUBLIC_API_BASE_URL=
+INTERNAL_API_BASE_URL=http://127.0.0.1:3000
 CORS_ALLOWED_ORIGIN=http://localhost:3000
 
 # Network

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ so Compose never offers to recreate an existing Mongo data volume.
 
 When hosting the frontend separately from the backend services, set `NEXT_PUBLIC_API_BASE_URL` to the backend origin (for example, `https://backend.test.com`). Browser requests use that base URL when provided and otherwise remain relative to the current origin. The same variable enables a framework rewrite so hitting `/api/*` on the frontend domain proxies to the backend.
 
-Set `INTERNAL_API_BASE_URL` to the trusted backend origin used by server-side admin requests. Use the external backend origin for split deployments and `http://127.0.0.1:3000` when the API runs in the same service. Server-side admin requests fail closed when this variable is missing and never derive their destination from request headers.
+Set `INTERNAL_API_BASE_URL` to the trusted backend origin used by server-side admin requests. Use the external backend origin for split deployments and `http://127.0.0.1:3000` when the API runs in the same service. When this variable is missing, server-side admin requests use the same trusted API target as the framework proxy; if neither target is available, they fail closed. They never derive their destination from request headers.
 
 Vercel testnet previews automatically proxy `/api/*` to `https://bridge-api.tanenbaum.io` when no explicit API base is configured. The testnet backend accepts HTTPS `*.vercel.app` origins for these preview requests. Mainnet previews are never automatically connected to the production backend, and the mainnet backend continues to require an exact `CORS_ALLOWED_ORIGIN` match.
 

--- a/README.md
+++ b/README.md
@@ -203,13 +203,16 @@ so Compose never offers to recreate an existing Mongo data volume.
 | `UTXO_SPONSOR_ADDRESS`          | Syscoin UTXO address used to fund sponsored mint and SYSX burn fees |         |
 | `UTXO_SPONSOR_WIF`              | WIF private key for the UTXO sponsor address    |         |
 | `NEXT_PUBLIC_API_BASE_URL`      | Base URL the frontend uses for API requests    |         |
+| `INTERNAL_API_BASE_URL`         | Trusted backend origin used by server-side admin requests |         |
 | `CORS_ALLOWED_ORIGIN`           | Allowed frontend origin(s) for API CORS responses (comma-separated, no `*` for admin cookie auth) |         |
 
 **Note**: API URLs are only used for EVM networks. UTXO networks use Blockbook which has a different API structure.
 
 ### Split Frontend/Backend Deployments
 
-When hosting the frontend separately from the backend services, set `NEXT_PUBLIC_API_BASE_URL` to the backend origin (for example, `https://backend.test.com`). All browser and server-side fetches automatically use that base URL when provided, and fall back to the current origin otherwise. The same variable also enables a framework rewrite so hitting `/api/*` on the frontend domain proxies to the backend. This lets a single build work for both combined and split deployments—just omit the variable when the API routes run alongside the frontend.
+When hosting the frontend separately from the backend services, set `NEXT_PUBLIC_API_BASE_URL` to the backend origin (for example, `https://backend.test.com`). Browser requests use that base URL when provided and otherwise remain relative to the current origin. The same variable enables a framework rewrite so hitting `/api/*` on the frontend domain proxies to the backend.
+
+Set `INTERNAL_API_BASE_URL` to the trusted backend origin used by server-side admin requests. Use the external backend origin for split deployments and `http://127.0.0.1:3000` when the API runs in the same service. Server-side admin requests fail closed when this variable is missing and never derive their destination from request headers.
 
 Vercel testnet previews automatically proxy `/api/*` to `https://bridge-api.tanenbaum.io` when no explicit API base is configured. The testnet backend accepts HTTPS `*.vercel.app` origins for these preview requests. Mainnet previews are never automatically connected to the production backend, and the mainnet backend continues to require an exact `CORS_ALLOWED_ORIGIN` match.
 

--- a/deploy/docker-compose.test.sh
+++ b/deploy/docker-compose.test.sh
@@ -46,7 +46,10 @@ BRIDGE_ENV_FILE="$test_dir/backend.env" \
           bridge.MONGO_ROOT_PASSWORD !== "compose-password") {
         throw new Error("Managed Compose lost the reconciled Mongo credentials");
       }
+      if (bridge.INTERNAL_API_BASE_URL !== "http://127.0.0.1:3000") {
+        throw new Error("Managed Compose did not provision the admin SSR origin");
+      }
     });
   '
 
-echo "Docker Compose Mongo configuration tests passed"
+echo "Docker Compose configuration tests passed"

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -86,6 +86,9 @@ services:
     environment:
       NODE_ENV: production
       HOSTNAME: 0.0.0.0
+      # Admin SSR runs in this same service and must never derive its API
+      # destination from request headers or an upgrade-persistent host env file.
+      INTERNAL_API_BASE_URL: "http://127.0.0.1:3000"
       # This managed Compose stack always uses its local authenticated Mongo.
       # Ignore legacy URIs whose embedded credentials can drift from the
       # initialized database volume.

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import AdminTransferList from "components/Admin/Transfer/List";
 import { ITransfer } from "@contexts/Transfer/types";
 import AdminTransferFilters from "components/Admin/Transfer/Filters";
-import { buildApiUrl } from "utils/api-base-url";
+import { buildInternalApiUrl } from "utils/api-base-url";
 type Props = {
   user: SessionUser;
   transfers: ITransfer[];
@@ -84,16 +84,9 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
     searchParams.set("page", page);
   }
 
-  const forwardedProto = req.headers["x-forwarded-proto"];
-  const protocol = (
-    Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
-  )?.split(",")[0]?.trim() || "http";
-  const host = req.headers.host || "localhost:3000";
-  const fallbackOrigin = `${protocol}://${host}`;
   const queryString = searchParams.toString();
-  const requestUrl = buildApiUrl(
-    `/api/admin/transfers${queryString ? `?${queryString}` : ""}`,
-    { fallbackOrigin }
+  const requestUrl = buildInternalApiUrl(
+    `/api/admin/transfers${queryString ? `?${queryString}` : ""}`
   );
 
   const response = await fetch(requestUrl, {

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps, NextPage } from "next";
-import { SessionUser, withSessionSsr } from "lib/session";
+import type { SessionUser } from "lib/session";
 import { Box, Button, Container, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import AdminTransferList from "components/Admin/Transfer/List";
@@ -68,78 +68,65 @@ export const AdminPage: NextPage<Props> = ({
 };
 
 // This gets called on every request
-export const getServerSideProps: GetServerSideProps = withSessionSsr(
-  async ({ req, query }) => {
-    const { user } = req.session;
+export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
+  const getQueryValue = (value?: string | string[]) =>
+    Array.isArray(value) ? value[0] : value;
 
-    if (!user) {
-      return {
-        redirect: {
-          destination: "/admin/login",
-          permanent: false,
-        },
-      };
-    }
+  const searchParams = new URLSearchParams();
+  const id = getQueryValue(query.id);
+  const page = getQueryValue(query.page);
 
-    const getQueryValue = (value?: string | string[]) =>
-      Array.isArray(value) ? value[0] : value;
+  if (id) {
+    searchParams.set("id", id);
+  }
 
-    const searchParams = new URLSearchParams();
-    const id = getQueryValue(query.id);
-    const page = getQueryValue(query.page);
+  if (page) {
+    searchParams.set("page", page);
+  }
 
-    if (id) {
-      searchParams.set("id", id);
-    }
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  const protocol = (
+    Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
+  )?.split(",")[0]?.trim() || "http";
+  const host = req.headers.host || "localhost:3000";
+  const fallbackOrigin = `${protocol}://${host}`;
+  const queryString = searchParams.toString();
+  const requestUrl = buildApiUrl(
+    `/api/admin/transfers${queryString ? `?${queryString}` : ""}`,
+    { fallbackOrigin }
+  );
 
-    if (page) {
-      searchParams.set("page", page);
-    }
+  const response = await fetch(requestUrl, {
+    headers: {
+      cookie: req.headers.cookie || "",
+    },
+  });
 
-    const forwardedProto = req.headers["x-forwarded-proto"];
-    const protocol = (
-      Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
-    )?.split(",")[0]?.trim() || "http";
-    const host = req.headers.host || "localhost:3000";
-    const fallbackOrigin = `${protocol}://${host}`;
-    const queryString = searchParams.toString();
-    const requestUrl = buildApiUrl(
-      `/api/admin/transfers${queryString ? `?${queryString}` : ""}`,
-      { fallbackOrigin }
-    );
-
-    const response = await fetch(requestUrl, {
-      headers: {
-        cookie: req.headers.cookie || "",
-      },
-    });
-
-    if (response.status === 401) {
-      return {
-        redirect: {
-          destination: "/admin/login",
-          permanent: false,
-        },
-      };
-    }
-
-    if (!response.ok) {
-      throw new Error("Failed to fetch admin transfers");
-    }
-
-    const { transfers, total, pageSize } = await response.json();
-
-    const props: Props = {
-      user,
-      transfers,
-      total,
-      pageSize,
-    };
-
+  if (response.status === 401) {
     return {
-      props,
+      redirect: {
+        destination: "/admin/login",
+        permanent: false,
+      },
     };
   }
-);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch admin transfers");
+  }
+
+  const { transfers, total, pageSize, user } = await response.json();
+
+  const props: Props = {
+    user,
+    transfers,
+    total,
+    pageSize,
+  };
+
+  return {
+    props,
+  };
+};
 
 export default AdminPage;

--- a/pages/admin/transfer/[id].tsx
+++ b/pages/admin/transfer/[id].tsx
@@ -24,7 +24,6 @@ import AddFreezeBurnTransactionModal from "components/Admin/Transfer/AddLogModal
 import AddMintSysxTransaction from "components/Admin/Transfer/AddLogModals/AddMintSysxTransaction";
 import { useConstants } from "@contexts/useConstants";
 import { buildApiUrl } from "utils/api-base-url";
-import { withSessionSsr } from "lib/session";
 
 type Props = {
   initialTransfer: ITransfer;
@@ -220,71 +219,61 @@ const TransferDetailsPage: NextPage<Props> = ({ initialTransfer }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = withSessionSsr(
-  async ({ params, req }) => {
-    const { user } = req.session;
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  req,
+}) => {
+  const rawId = params?.["id"];
+  const id = Array.isArray(rawId) ? rawId[0] : rawId;
 
-    if (!user) {
-      return {
-        redirect: {
-          destination: "/admin/login",
-          permanent: false,
-        },
-      };
-    }
-
-    const rawId = params?.["id"];
-    const id = Array.isArray(rawId) ? rawId[0] : rawId;
-
-    if (!id) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const forwardedProto = req.headers["x-forwarded-proto"];
-    const protocol = (
-      Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
-    )?.split(",")[0]?.trim() || "http";
-    const host = req.headers.host || "localhost:3000";
-    const fallbackOrigin = `${protocol}://${host}`;
-    const requestUrl = buildApiUrl(`/api/admin/transfers/${id}`, {
-      fallbackOrigin,
-    });
-
-    const response = await fetch(requestUrl, {
-      headers: {
-        cookie: req.headers.cookie || "",
-      },
-    });
-
-    if (response.status === 401) {
-      return {
-        redirect: {
-          destination: "/admin/login",
-          permanent: false,
-        },
-      };
-    }
-
-    if (response.status === 404) {
-      return {
-        notFound: true,
-      };
-    }
-
-    if (!response.ok) {
-      throw new Error("Failed to fetch transfer");
-    }
-
-    const transfer = await response.json();
-
+  if (!id) {
     return {
-      props: {
-        initialTransfer: transfer,
+      notFound: true,
+    };
+  }
+
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  const protocol = (
+    Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
+  )?.split(",")[0]?.trim() || "http";
+  const host = req.headers.host || "localhost:3000";
+  const fallbackOrigin = `${protocol}://${host}`;
+  const requestUrl = buildApiUrl(`/api/admin/transfers/${id}`, {
+    fallbackOrigin,
+  });
+
+  const response = await fetch(requestUrl, {
+    headers: {
+      cookie: req.headers.cookie || "",
+    },
+  });
+
+  if (response.status === 401) {
+    return {
+      redirect: {
+        destination: "/admin/login",
+        permanent: false,
       },
     };
   }
-);
+
+  if (response.status === 404) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch transfer");
+  }
+
+  const transfer = await response.json();
+
+  return {
+    props: {
+      initialTransfer: transfer,
+    },
+  };
+};
 
 export default TransferDetailsPage;

--- a/pages/admin/transfer/[id].tsx
+++ b/pages/admin/transfer/[id].tsx
@@ -23,7 +23,7 @@ import { Web3Provider } from "components/Bridge/context/Web";
 import AddFreezeBurnTransactionModal from "components/Admin/Transfer/AddLogModals/AddFreezeBurnTransactionModal";
 import AddMintSysxTransaction from "components/Admin/Transfer/AddLogModals/AddMintSysxTransaction";
 import { useConstants } from "@contexts/useConstants";
-import { buildApiUrl } from "utils/api-base-url";
+import { buildInternalApiUrl } from "utils/api-base-url";
 
 type Props = {
   initialTransfer: ITransfer;
@@ -232,15 +232,9 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
-  const forwardedProto = req.headers["x-forwarded-proto"];
-  const protocol = (
-    Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
-  )?.split(",")[0]?.trim() || "http";
-  const host = req.headers.host || "localhost:3000";
-  const fallbackOrigin = `${protocol}://${host}`;
-  const requestUrl = buildApiUrl(`/api/admin/transfers/${id}`, {
-    fallbackOrigin,
-  });
+  const requestUrl = buildInternalApiUrl(
+    `/api/admin/transfers/${encodeURIComponent(id)}`
+  );
 
   const response = await fetch(requestUrl, {
     headers: {

--- a/pages/api/admin/transfers/index.ts
+++ b/pages/api/admin/transfers/index.ts
@@ -36,6 +36,7 @@ const AdminTransfersHandler: NextApiHandler = adminSessionGuard(
       transfers,
       total,
       pageSize: PAGE_SIZE,
+      user: req.session.user,
     });
   }
 );

--- a/utils/admin-pages-router.test.ts
+++ b/utils/admin-pages-router.test.ts
@@ -11,4 +11,23 @@ describe("admin Pages Router components", () => {
     expect(source).toContain('from "next/router"');
     expect(source).not.toContain('from "next/navigation"');
   });
+
+  it.each(["pages/admin/index.tsx", "pages/admin/transfer/[id].tsx"])(
+    "delegates session validation to the backend in %s",
+    (relativePath) => {
+      const source = readFileSync(join(process.cwd(), relativePath), "utf8");
+
+      expect(source).not.toContain("withSessionSsr");
+      expect(source).toContain("response.status === 401");
+    }
+  );
+
+  it("returns the authenticated user with the transfer list", () => {
+    const source = readFileSync(
+      join(process.cwd(), "pages/api/admin/transfers/index.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("user: req.session.user");
+  });
 });

--- a/utils/admin-pages-router.test.ts
+++ b/utils/admin-pages-router.test.ts
@@ -22,6 +22,18 @@ describe("admin Pages Router components", () => {
     }
   );
 
+  it.each(["pages/admin/index.tsx", "pages/admin/transfer/[id].tsx"])(
+    "uses only the configured internal API origin in %s",
+    (relativePath) => {
+      const source = readFileSync(join(process.cwd(), relativePath), "utf8");
+
+      expect(source).toContain("buildInternalApiUrl");
+      expect(source).not.toContain('req.headers["x-forwarded-proto"]');
+      expect(source).not.toContain("req.headers.host");
+      expect(source).not.toContain("fallbackOrigin");
+    }
+  );
+
   it("returns the authenticated user with the transfer list", () => {
     const source = readFileSync(
       join(process.cwd(), "pages/api/admin/transfers/index.ts"),

--- a/utils/api-base-url.test.ts
+++ b/utils/api-base-url.test.ts
@@ -1,0 +1,48 @@
+import { buildInternalApiUrl } from "./api-base-url";
+
+describe("buildInternalApiUrl", () => {
+  const originalInternalApiBaseUrl = process.env.INTERNAL_API_BASE_URL;
+  const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  afterEach(() => {
+    if (originalInternalApiBaseUrl === undefined) {
+      delete process.env.INTERNAL_API_BASE_URL;
+    } else {
+      process.env.INTERNAL_API_BASE_URL = originalInternalApiBaseUrl;
+    }
+
+    if (originalPublicApiBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_BASE_URL = originalPublicApiBaseUrl;
+    }
+  });
+
+  it("builds an absolute URL from the configured internal API origin", () => {
+    process.env.INTERNAL_API_BASE_URL = " https://api.example.test/// ";
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://public.example.test";
+
+    expect(buildInternalApiUrl("api/admin/transfers?page=2")).toBe(
+      "https://api.example.test/api/admin/transfers?page=2"
+    );
+  });
+
+  it("fails closed when the internal API origin is missing", () => {
+    delete process.env.INTERNAL_API_BASE_URL;
+
+    expect(() => buildInternalApiUrl("/api/admin/transfers")).toThrow(
+      "INTERNAL_API_BASE_URL is required for server-side API requests"
+    );
+  });
+
+  it.each(["file:///tmp/bridge", "javascript:alert(1)"])(
+    "rejects a non-HTTP internal API origin: %s",
+    (baseUrl) => {
+      process.env.INTERNAL_API_BASE_URL = baseUrl;
+
+      expect(() => buildInternalApiUrl("/api/admin/transfers")).toThrow(
+        "INTERNAL_API_BASE_URL must use HTTP or HTTPS"
+      );
+    }
+  );
+});

--- a/utils/api-base-url.test.ts
+++ b/utils/api-base-url.test.ts
@@ -1,20 +1,25 @@
 import { buildInternalApiUrl } from "./api-base-url";
 
 describe("buildInternalApiUrl", () => {
-  const originalInternalApiBaseUrl = process.env.INTERNAL_API_BASE_URL;
-  const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const envNames = [
+    "INTERNAL_API_BASE_URL",
+    "NEXT_PUBLIC_API_BASE_URL",
+    "VERCEL_ENV",
+    "IS_TESTNET",
+    "NEXT_PUBLIC_IS_TESTNET",
+  ] as const;
+  const originalEnv = Object.fromEntries(
+    envNames.map((name) => [name, process.env[name]])
+  );
 
   afterEach(() => {
-    if (originalInternalApiBaseUrl === undefined) {
-      delete process.env.INTERNAL_API_BASE_URL;
-    } else {
-      process.env.INTERNAL_API_BASE_URL = originalInternalApiBaseUrl;
-    }
-
-    if (originalPublicApiBaseUrl === undefined) {
-      delete process.env.NEXT_PUBLIC_API_BASE_URL;
-    } else {
-      process.env.NEXT_PUBLIC_API_BASE_URL = originalPublicApiBaseUrl;
+    for (const name of envNames) {
+      const value = originalEnv[name];
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
     }
   });
 
@@ -29,6 +34,32 @@ describe("buildInternalApiUrl", () => {
 
   it("fails closed when the internal API origin is missing", () => {
     delete process.env.INTERNAL_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    delete process.env.VERCEL_ENV;
+    delete process.env.IS_TESTNET;
+    delete process.env.NEXT_PUBLIC_IS_TESTNET;
+
+    expect(() => buildInternalApiUrl("/api/admin/transfers")).toThrow(
+      "INTERNAL_API_BASE_URL is required for server-side API requests"
+    );
+  });
+
+  it("uses the trusted proxy target for a testnet Vercel preview", () => {
+    delete process.env.INTERNAL_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    process.env.VERCEL_ENV = "preview";
+    process.env.NEXT_PUBLIC_IS_TESTNET = "true";
+
+    expect(buildInternalApiUrl("/api/admin/transfers")).toBe(
+      "https://bridge-api.tanenbaum.io/api/admin/transfers"
+    );
+  });
+
+  it("fails closed for a mainnet Vercel preview without a target", () => {
+    delete process.env.INTERNAL_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    process.env.VERCEL_ENV = "preview";
+    process.env.NEXT_PUBLIC_IS_TESTNET = "false";
 
     expect(() => buildInternalApiUrl("/api/admin/transfers")).toThrow(
       "INTERNAL_API_BASE_URL is required for server-side API requests"

--- a/utils/api-base-url.ts
+++ b/utils/api-base-url.ts
@@ -1,3 +1,5 @@
+import { resolveApiProxyTarget } from "./api-proxy-target";
+
 const stripTrailingSlashes = (value: string) => {
   let end = value.length;
   while (end > 0 && value[end - 1] === "/") {
@@ -18,7 +20,7 @@ export const API_BASE_URL = getApiBaseUrl();
 
 const getInternalApiBaseUrl = () => {
   const baseUrl = stripTrailingSlashes(
-    (process.env.INTERNAL_API_BASE_URL || "").trim()
+    (process.env.INTERNAL_API_BASE_URL || resolveApiProxyTarget()).trim()
   );
 
   if (!baseUrl) {

--- a/utils/api-base-url.ts
+++ b/utils/api-base-url.ts
@@ -16,20 +16,37 @@ const getApiBaseUrl = () => {
 
 export const API_BASE_URL = getApiBaseUrl();
 
-type BuildApiUrlOptions = {
-  fallbackOrigin?: string;
+const getInternalApiBaseUrl = () => {
+  const baseUrl = stripTrailingSlashes(
+    (process.env.INTERNAL_API_BASE_URL || "").trim()
+  );
+
+  if (!baseUrl) {
+    throw new Error(
+      "INTERNAL_API_BASE_URL is required for server-side API requests"
+    );
+  }
+
+  const protocol = new URL(baseUrl).protocol;
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw new Error("INTERNAL_API_BASE_URL must use HTTP or HTTPS");
+  }
+
+  return baseUrl;
 };
 
-export const buildApiUrl = (
-  path: string,
-  options?: BuildApiUrlOptions
-): string => {
+export const buildApiUrl = (path: string): string => {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const baseUrl = getApiBaseUrl() || options?.fallbackOrigin || "";
+  const baseUrl = getApiBaseUrl();
 
   if (!baseUrl) {
     return normalizedPath;
   }
 
   return `${baseUrl}${normalizedPath}`;
+};
+
+export const buildInternalApiUrl = (path: string): string => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${getInternalApiBaseUrl()}${normalizedPath}`;
 };


### PR DESCRIPTION
## Summary
- delegate admin session validation to the backend API that owns the session cookie
- return the authenticated admin identity with the protected transfer-list response
- keep unauthenticated admin SSR redirects and detail-page authorization enforced by backend 401 responses

## Live diagnosis
After PR #89 deployed, both backend-rendered admin pages returned 200, but both Vercel admin pages returned 500 even without a cookie. The frontend API proxy and direct backend API returned 200 with the same authenticated cookie. This isolates the remaining failure to the Vercel SSR session wrapper requiring a missing or invalid duplicate session password.

## Validation
- focused admin routing/session tests: 11 passed
- full test suite: 27 suites, 140 tests passed
- lint: clean
- production build: passed on Node 24
- compiled admin SSR succeeds with SECRET_COOKIE_PASSWORD absent and a backend-authenticated response