### PR TITLE
Preserve exact bridge amounts

### DIFF
--- a/api/services/__tests__/sponsor-wallet.test.ts
+++ b/api/services/__tests__/sponsor-wallet.test.ts
@@ -55,17 +55,10 @@ jest.mock("models/sponsor-utxo-reservation", () => {
   };
 });
 
-jest.mock("satoshi-bitcoin", () => ({
-  __esModule: true,
-  default: {
-    toSatoshi: jest.fn(() => 100_000),
-  },
-}));
-
 jest.mock("syscoinjs-lib", () => ({
   syscoin: jest.fn(),
   utils: {
-    BN: jest.fn(function (this: any, value: number) {
+    BN: jest.fn(function (this: any, value: string | number) {
       this.value = value;
     }),
     syscoinNetworks: {

--- a/api/services/sponsor-utxo-eligibility.ts
+++ b/api/services/sponsor-utxo-eligibility.ts
@@ -5,8 +5,8 @@ import {
   ETH_TO_SYS_TRANSFER_STATUS,
   ITransfer,
 } from "@contexts/Transfer/types";
-import satoshibitcoin from "satoshi-bitcoin";
 import web3 from "utils/get-web3";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 import { AbiItem, toWei } from "web3-utils";
 import { assertV2ActivationBlock } from "./sponsor-eligibility";
 
@@ -39,7 +39,9 @@ export const assertSponsoredUtxoTransfer = (transfer: ITransfer) => {
   if (!transfer.utxoAddress || !transfer.utxoXpub || !transfer.nevmAddress) {
     throw new Error("Missing transfer addresses");
   }
-  if (Number(transfer.amount) < MIN_AMOUNT) {
+  const amountBaseUnits = BigInt(toSyscoinBaseUnits(transfer.amount));
+  const minimumBaseUnits = BigInt(toSyscoinBaseUnits(MIN_AMOUNT.toString()));
+  if (amountBaseUnits < minimumBaseUnits) {
     throw new Error("Transfer amount is below the bridge minimum");
   }
 };
@@ -91,9 +93,7 @@ export const assertSponsoredMintEligible = async (
     throw new Error("Freeze and burn transaction does not match this transfer");
   }
 
-  const amountSats = Math.ceil(
-    satoshibitcoin.toSatoshi(transfer.amount.toString())
-  ).toString();
+  const amountSats = toSyscoinBaseUnits(transfer.amount);
   const matchingEvent = receipt.logs.some((log) => {
     if (
       !log.address ||

--- a/api/services/sponsor-wallet.ts
+++ b/api/services/sponsor-wallet.ts
@@ -7,9 +7,9 @@ import SponsorWalletTransactions, {
   ISponsorWalletTransaction,
   SponsorWalletTransactionAction,
 } from "models/sponsor-wallet-transactions";
-import satoshibitcoin from "satoshi-bitcoin";
 import { syscoin, UTXOTransaction, utils as syscoinUtils } from "syscoinjs-lib";
 import web3 from "utils/get-web3";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 import {
   MAINNET_BLOCKBOOK_URL,
   resolveUtxoBlockbookUrl,
@@ -675,9 +675,7 @@ export class SponsorWalletService {
           changeAddress: transfer.utxoAddress,
           outputs: [
             {
-              value: new syscoinUtils.BN(
-                Math.ceil(satoshibitcoin.toSatoshi(transfer.amount))
-              ),
+              value: new syscoinUtils.BN(toSyscoinBaseUnits(transfer.amount)),
               address: transfer.utxoAddress,
             },
           ],

--- a/components/Bridge/Steps/ConnectValidate.tsx
+++ b/components/Bridge/Steps/ConnectValidate.tsx
@@ -10,6 +10,7 @@ import {
   useFormContext,
 } from "react-hook-form";
 import { useNevmBalance, useUtxoBalance } from "utils/balance-hooks";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 
 import { MIN_AMOUNT, MIN_GAS_AMOUNT } from "@constants";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
@@ -72,7 +73,7 @@ const NEVMWrapped: React.FC<{ transfer: ITransfer }> = ({ transfer }) => {
 };
 
 type ConnectValidateFormData = {
-  amount: number;
+  amount: string;
   nevmAddress: string;
   utxoAddress: string;
   utxoXpub: string;
@@ -81,7 +82,7 @@ type ConnectValidateFormData = {
 };
 
 export type ConnectValidateDraft = {
-  amount?: number;
+  amount?: string;
   nevmAddress: string;
   utxoAddress: string;
   utxoXpub: string;
@@ -94,21 +95,24 @@ type BridgeConnectValidateStepProps = {
 };
 
 const parseTransferAmount = (amount: string) => {
-  const parsedAmount = Number(amount);
-
-  return Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : 0.1;
+  try {
+    toSyscoinBaseUnits(amount);
+    return amount;
+  } catch {
+    return "0.1";
+  }
 };
 
 const hasDraftFormValues = (
   amount: string,
   utxoAssetType?: "sys" | "sysx"
 ) => {
-  const parsedAmount = Number(amount);
-
-  return (
-    (Number.isFinite(parsedAmount) && parsedAmount > 0) ||
-    Boolean(utxoAssetType)
-  );
+  try {
+    toSyscoinBaseUnits(amount);
+    return true;
+  } catch {
+    return Boolean(utxoAssetType);
+  }
 };
 
 const BridgeConnectValidateStep: React.FC<
@@ -139,8 +143,16 @@ const BridgeConnectValidateStep: React.FC<
   const nevmAddress = watch("nevmAddress");
 
   useEffect(() => {
+    let draftAmount: string | undefined;
+    try {
+      toSyscoinBaseUnits(amount);
+      draftAmount = amount;
+    } catch {
+      draftAmount = undefined;
+    }
+
     onDraftChange?.({
-      amount: Number.isFinite(amount) ? amount : undefined,
+      amount: draftAmount,
       nevmAddress,
       utxoAddress,
       utxoXpub,
@@ -164,7 +176,7 @@ const BridgeConnectValidateStep: React.FC<
       !hasDraftFormValues(transfer.amount, transfer.utxoAssetType)
     ) {
       reset({
-        amount: 0.1,
+        amount: "0.1",
         nevmAddress: "",
         utxoAddress: "",
         utxoXpub: "",
@@ -210,7 +222,7 @@ const BridgeConnectValidateStep: React.FC<
     const { amount, ...rest } = data;
     const modifiedTransfer: ITransfer = {
       ...transfer,
-      amount: amount.toString(),
+      amount,
       ...rest,
       useSysx,
       status:

--- a/components/Bridge/Steps/ConnectValidate.tsx
+++ b/components/Bridge/Steps/ConnectValidate.tsx
@@ -9,8 +9,14 @@ import {
   useForm,
   useFormContext,
 } from "react-hook-form";
-import { useNevmBalance, useUtxoBalance } from "utils/balance-hooks";
-import { toSyscoinBaseUnits } from "utils/syscoin-amount";
+import {
+  useNevmBalanceBaseUnits,
+  useUtxoBalanceBaseUnits,
+} from "utils/balance-hooks";
+import {
+  getTransferableSyscoinBaseUnits,
+  toSyscoinBaseUnits,
+} from "utils/syscoin-amount";
 
 import { MIN_AMOUNT, MIN_GAS_AMOUNT } from "@constants";
 import { usePaliWalletV2 } from "@contexts/PaliWallet/usePaliWallet";
@@ -194,27 +200,26 @@ const BridgeConnectValidateStep: React.FC<
     transfer.utxoAssetType,
   ]);
 
-  const utxoBalance = useUtxoBalance(utxoXpub);
-  const sysxBalance = useUtxoBalance(utxoXpub, {
+  const utxoBalance = useUtxoBalanceBaseUnits(utxoXpub);
+  const sysxBalance = useUtxoBalanceBaseUnits(utxoXpub, {
     address: utxoAddress,
     assetGuid: SYSX_ASSET_GUID,
   });
-  const nevmBalance = useNevmBalance(nevmAddress);
+  const nevmBalance = useNevmBalanceBaseUnits(nevmAddress);
 
   const useSysx = utxoAssetType === "sysx";
 
-  const maxUtxoAmount = useSysx ? sysxBalance.data : utxoBalance.data;
-
-  const maxAmmount =
-    transfer.type === "sys-to-nevm" ? maxUtxoAmount : nevmBalance.data;
-
-  let maxAmountCalculated =
-    parseFloat(`${maxAmmount ?? "0"}`) -
-    (transfer.type === "sys-to-nevm" && useSysx ? 0 : MIN_GAS_AMOUNT);
-
-  if (maxAmountCalculated < 0) {
-    maxAmountCalculated = 0;
-  }
+  const maxUtxoBalance = useSysx ? sysxBalance.data : utxoBalance.data;
+  const maxBalance =
+    transfer.type === "sys-to-nevm" ? maxUtxoBalance : nevmBalance.data;
+  const maximumBaseUnits = getTransferableSyscoinBaseUnits({
+    balanceBaseUnits: maxBalance ?? "0",
+    balanceDecimals: transfer.type === "sys-to-nevm" ? 8 : 18,
+    reserveBaseUnits:
+      transfer.type === "sys-to-nevm" && useSysx
+        ? "0"
+        : toSyscoinBaseUnits(MIN_GAS_AMOUNT.toString()),
+  });
 
   const modifiedTransfer = { ...transfer, utxoAddress, utxoXpub, nevmAddress };
 
@@ -267,9 +272,9 @@ const BridgeConnectValidateStep: React.FC<
           )}
         </Box>
         <ConnectValidateAmountField
-          maxAmountCalculated={maxAmountCalculated}
+          maximumBaseUnits={maximumBaseUnits}
           minAmount={MIN_AMOUNT}
-          balance={maxAmmount}
+          balanceLoaded={maxBalance !== undefined}
           transfer={modifiedTransfer}
         />
         <ConnectValidateAgreeToTermsCheckbox />

--- a/components/Bridge/Steps/ConnectValidate/AmountField.tsx
+++ b/components/Bridge/Steps/ConnectValidate/AmountField.tsx
@@ -8,21 +8,21 @@ import {
 } from "@mui/material";
 import { useFormContext } from "react-hook-form";
 import {
-  floorSyscoinBaseUnits,
+  formatSyscoinBaseUnits,
   toSyscoinBaseUnits,
 } from "utils/syscoin-amount";
 
 type Props = {
-  maxAmountCalculated: number;
+  maximumBaseUnits: string;
   minAmount: number;
-  balance?: number;
+  balanceLoaded: boolean;
   transfer: ITransfer;
 };
 
 export const ConnectValidateAmountField: React.FC<Props> = ({
-  maxAmountCalculated,
+  maximumBaseUnits,
   minAmount,
-  balance,
+  balanceLoaded,
   transfer,
 }) => {
   const {
@@ -33,9 +33,7 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
   const utxoAssetType = watch("utxoAssetType");
   const showSysx = transfer.type === "sys-to-nevm" && utxoAssetType === "sysx";
   const minimumBaseUnits = BigInt(toSyscoinBaseUnits(minAmount.toString()));
-  const maximumBaseUnits = BigInt(
-    floorSyscoinBaseUnits(maxAmountCalculated)
-  );
+  const maximum = BigInt(maximumBaseUnits);
 
   return (
     <Box>
@@ -78,8 +76,10 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
             maximum: (value: string) => {
               try {
                 return (
-                  BigInt(toSyscoinBaseUnits(value)) <= maximumBaseUnits ||
-                  `You can transfer up to ${maxAmountCalculated.toFixed(4)} ${
+                  BigInt(toSyscoinBaseUnits(value)) <= maximum ||
+                  `You can transfer up to ${formatSyscoinBaseUnits(
+                    maximumBaseUnits
+                  )} ${
                     showSysx ? "SYSX" : "SYS"
                   }`
                 );
@@ -89,7 +89,7 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
             },
           },
         })}
-        disabled={balance === undefined}
+        disabled={!balanceLoaded}
         error={!!errors.amount}
         helperText={<>{errors.amount && errors.amount.message}</>}
         sx={{ mb: 2 }}

--- a/components/Bridge/Steps/ConnectValidate/AmountField.tsx
+++ b/components/Bridge/Steps/ConnectValidate/AmountField.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useFormContext } from "react-hook-form";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 
 type Props = {
   maxAmountCalculated: number;
@@ -28,6 +29,12 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
   } = useFormContext();
   const utxoAssetType = watch("utxoAssetType");
   const showSysx = transfer.type === "sys-to-nevm" && utxoAssetType === "sysx";
+  const minimumBaseUnits = BigInt(toSyscoinBaseUnits(minAmount.toString()));
+  const maximumBaseUnits =
+    maxAmountCalculated > 0
+      ? BigInt(toSyscoinBaseUnits(maxAmountCalculated.toFixed(8)))
+      : BigInt(0);
+
   return (
     <Box>
       <TextField
@@ -43,22 +50,42 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
           ),
         }}
         {...register("amount", {
-          valueAsNumber: true,
-          max: {
-            value: maxAmountCalculated,
-            message: `You can transfer up to ${maxAmountCalculated.toFixed(
-              4
-            )} ${showSysx ? "SYSX" : "SYS"}`,
-          },
-          min: {
-            value: minAmount,
-            message: `Amount must be at least ${minAmount}`,
-          },
           required: {
             message: "Amount is required",
             value: true,
           },
-          validate: (value) => (isNaN(value) ? "Must be a number" : undefined),
+          validate: {
+            validAmount: (value: string) => {
+              try {
+                toSyscoinBaseUnits(value);
+                return true;
+              } catch (error) {
+                return error instanceof Error ? error.message : "Invalid amount";
+              }
+            },
+            minimum: (value: string) => {
+              try {
+                return (
+                  BigInt(toSyscoinBaseUnits(value)) >= minimumBaseUnits ||
+                  `Amount must be at least ${minAmount}`
+                );
+              } catch {
+                return true;
+              }
+            },
+            maximum: (value: string) => {
+              try {
+                return (
+                  BigInt(toSyscoinBaseUnits(value)) <= maximumBaseUnits ||
+                  `You can transfer up to ${maxAmountCalculated.toFixed(4)} ${
+                    showSysx ? "SYSX" : "SYS"
+                  }`
+                );
+              } catch {
+                return true;
+              }
+            },
+          },
         })}
         disabled={balance === undefined}
         error={!!errors.amount}

--- a/components/Bridge/Steps/ConnectValidate/AmountField.tsx
+++ b/components/Bridge/Steps/ConnectValidate/AmountField.tsx
@@ -7,7 +7,10 @@ import {
   Typography,
 } from "@mui/material";
 import { useFormContext } from "react-hook-form";
-import { toSyscoinBaseUnits } from "utils/syscoin-amount";
+import {
+  toNonnegativeSyscoinBaseUnits,
+  toSyscoinBaseUnits,
+} from "utils/syscoin-amount";
 
 type Props = {
   maxAmountCalculated: number;
@@ -30,10 +33,11 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
   const utxoAssetType = watch("utxoAssetType");
   const showSysx = transfer.type === "sys-to-nevm" && utxoAssetType === "sysx";
   const minimumBaseUnits = BigInt(toSyscoinBaseUnits(minAmount.toString()));
-  const maximumBaseUnits =
-    maxAmountCalculated > 0
-      ? BigInt(toSyscoinBaseUnits(maxAmountCalculated.toFixed(8)))
-      : BigInt(0);
+  const maximumBaseUnits = BigInt(
+    toNonnegativeSyscoinBaseUnits(
+      Math.max(0, maxAmountCalculated).toFixed(8)
+    )
+  );
 
   return (
     <Box>

--- a/components/Bridge/Steps/ConnectValidate/AmountField.tsx
+++ b/components/Bridge/Steps/ConnectValidate/AmountField.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { useFormContext } from "react-hook-form";
 import {
-  toNonnegativeSyscoinBaseUnits,
+  floorSyscoinBaseUnits,
   toSyscoinBaseUnits,
 } from "utils/syscoin-amount";
 
@@ -34,9 +34,7 @@ export const ConnectValidateAmountField: React.FC<Props> = ({
   const showSysx = transfer.type === "sys-to-nevm" && utxoAssetType === "sysx";
   const minimumBaseUnits = BigInt(toSyscoinBaseUnits(minAmount.toString()));
   const maximumBaseUnits = BigInt(
-    toNonnegativeSyscoinBaseUnits(
-      Math.max(0, maxAmountCalculated).toFixed(8)
-    )
+    floorSyscoinBaseUnits(maxAmountCalculated)
   );
 
   return (

--- a/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
+++ b/components/Bridge/Steps/ConnectValidate/StartTransferButton.tsx
@@ -8,7 +8,10 @@ import {
   isValidSYSAddress,
 } from "@sidhujag/sysweb3-utils";
 import { useFormContext } from "react-hook-form";
-import { useNevmBalance, useUtxoBalance } from "utils/balance-hooks";
+import {
+  useNevmBalanceBaseUnits,
+  useUtxoBalanceBaseUnits,
+} from "utils/balance-hooks";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import { useConstants } from "@contexts/useConstants";
 import { useNEVM } from "@contexts/ConnectedWallet/NEVMProvider";
@@ -17,6 +20,10 @@ import {
   getSyscoinChainId,
   resolveSyscoinIsTestnet,
 } from "utils/network-config";
+import {
+  getTransferableSyscoinBaseUnits,
+  toSyscoinBaseUnits,
+} from "utils/syscoin-amount";
 
 const ErrorMessage = ({ message }: { message: string }) => (
   <Box sx={{ display: "flex", mb: 2 }}>
@@ -44,12 +51,24 @@ export const ConnectValidateStartTransferButton: React.FC<{
   const utxoAssetType = watch("utxoAssetType");
   const useSysx = utxoAssetType === "sysx";
   const amount = watch("amount");
-  const utxoBalance = useUtxoBalance(utxoXpub);
-  const sysxBalance = useUtxoBalance(utxoXpub, {
+  const utxoBalance = useUtxoBalanceBaseUnits(utxoXpub);
+  const sysxBalance = useUtxoBalanceBaseUnits(utxoXpub, {
     address: utxoAddress,
     assetGuid: SYSX_ASSET_GUID,
   });
-  const nevmBalance = useNevmBalance(nevmAddress);
+  const nevmBalance = useNevmBalanceBaseUnits(nevmAddress);
+  const minimumAmountBaseUnits = BigInt(
+    toSyscoinBaseUnits(MIN_AMOUNT.toString())
+  );
+  const minimumGasBaseUnits = BigInt(
+    toSyscoinBaseUnits(MIN_GAS_AMOUNT.toString())
+  );
+  let amountBaseUnits: bigint | undefined;
+  try {
+    amountBaseUnits = BigInt(toSyscoinBaseUnits(amount));
+  } catch {
+    amountBaseUnits = undefined;
+  }
 
   const foundationFundingAvailable =
     isEnabled("foundationFundingAvailable") && transfer.type === "sys-to-nevm";
@@ -63,20 +82,28 @@ export const ConnectValidateStartTransferButton: React.FC<{
     Boolean(nevmAddress) &&
     nevmBalance.isFetched &&
     nevmBalance.data !== undefined &&
-    nevmBalance.data < MIN_GAS_AMOUNT;
+    BigInt(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: nevmBalance.data,
+        balanceDecimals: 18,
+        reserveBaseUnits: "0",
+      })
+    ) < minimumGasBaseUnits;
 
   const isUtxoNotEnoughGas =
     !utxoSponsorshipAvailable &&
     Boolean(utxoXpub) &&
     utxoBalance.isFetched &&
     utxoBalance.data !== undefined &&
-    utxoBalance.data < MIN_GAS_AMOUNT;
+    BigInt(utxoBalance.data) < minimumGasBaseUnits;
 
   const isSysxNotEnoughBalance =
     useSysx &&
     transfer.type === "sys-to-nevm" &&
     sysxBalance.data !== undefined &&
-    (sysxBalance.data < MIN_AMOUNT || sysxBalance.data < amount);
+    (BigInt(sysxBalance.data) < minimumAmountBaseUnits ||
+      (amountBaseUnits !== undefined &&
+        BigInt(sysxBalance.data) < amountBaseUnits));
   const isNevmWrongNetwork = Boolean(nevmAddress) && !isExpectedChain;
 
   const isUtxoValid =

--- a/contexts/Transfer/functions/burnSysToSysx.ts
+++ b/contexts/Transfer/functions/burnSysToSysx.ts
@@ -1,5 +1,5 @@
 import { syscoin, utils as syscoinUtils } from "syscoinjs-lib";
-import satoshibitcoin from "satoshi-bitcoin";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 import { SYSX_ASSET_GUID } from "../constants";
 
 export const burnSysToSysx = async (
@@ -19,7 +19,7 @@ export const burnSysToSysx = async (
         changeAddress: assetChangeAddress,
         outputs: [
           {
-            value: new syscoinUtils.BN(satoshibitcoin.toSatoshi(amount)),
+            value: new syscoinUtils.BN(toSyscoinBaseUnits(amount)),
             address: assetChangeAddress,
           },
         ],

--- a/contexts/Transfer/functions/burnSysx.ts
+++ b/contexts/Transfer/functions/burnSysx.ts
@@ -1,5 +1,5 @@
 import { syscoin, utils as syscoinUtils } from "syscoinjs-lib";
-import satoshibitcoin from "satoshi-bitcoin";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 import { SYSX_ASSET_GUID } from "../constants";
 
 export const burnSysx = async (
@@ -21,7 +21,7 @@ export const burnSysx = async (
         changeAddress: assetChangeAddress,
         outputs: [
           {
-            value: new syscoinUtils.BN(satoshibitcoin.toSatoshi(amount)),
+            value: new syscoinUtils.BN(toSyscoinBaseUnits(amount)),
             address: sysChangeAddress,
           },
         ],

--- a/contexts/Transfer/functions/sysToNevm.ts
+++ b/contexts/Transfer/functions/sysToNevm.ts
@@ -47,7 +47,7 @@ const runWithSysToNevmStateMachine = async (
       }
       const burnSysTransaction = await burnSysToSysx(
         syscoinInstance,
-        parseFloat(transfer.amount).toFixed(6),
+        transfer.amount,
         transfer.utxoXpub!,
         transfer.utxoAddress!
       );

--- a/contexts/Transfer/syscoinjs-lib.d.ts
+++ b/contexts/Transfer/syscoinjs-lib.d.ts
@@ -109,11 +109,6 @@ declare module "syscoinjs-lib" {
   }
 }
 
-declare module "satoshi-bitcoin" {
-  export function toSatoshi(amount: number | string): number;
-  export function toBitcoin(amount: number | string): number;
-}
-
 declare module "bitcoin-proof" {
   export function getProof(
     txIds: string[],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.31.3",
     "react-query": "^3.39.1",
-    "satoshi-bitcoin": "^1.0.5",
     "syscoinjs-lib": "^1.0.273",
     "web3": "1.10.4"
   },

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -31,6 +31,18 @@ import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
 import BridgeTransferSwitchTypeCard from "components/Bridge/TransferSwitchTypeCard";
 import BridgeNewTransferButton from "components/Bridge/NewTransferButton";
+import { toSyscoinBaseUnits } from "utils/syscoin-amount";
+
+const getDraftAmount = (amount?: string) => {
+  if (amount === undefined) return undefined;
+
+  try {
+    toSyscoinBaseUnits(amount);
+    return amount;
+  } catch {
+    return undefined;
+  }
+};
 
 const NewTransferButton = () => {
   const { transfer } = useTransfer();
@@ -45,23 +57,24 @@ const NewTransferButton = () => {
 const createTransfer = (
   type: TransferType,
   draft: Partial<ConnectValidateDraft> = {}
-): ITransfer => ({
-  amount: "0",
-  id: crypto.randomUUID(),
-  type,
-  status: COMMON_STATUS.INITIALIZE,
-  logs: [],
-  createdAt: Date.now(),
-  version: "v2",
-  agreedToTerms: false,
-  ...(draft.amount !== undefined && Number.isFinite(draft.amount)
-    ? { amount: draft.amount.toString() }
-    : {}),
-  nevmAddress: draft.nevmAddress || undefined,
-  utxoAddress: draft.utxoAddress || undefined,
-  utxoXpub: draft.utxoXpub || undefined,
-  utxoAssetType: draft.utxoAssetType,
-});
+): ITransfer => {
+  const amount = getDraftAmount(draft.amount);
+
+  return {
+    amount: amount ?? "0",
+    id: crypto.randomUUID(),
+    type,
+    status: COMMON_STATUS.INITIALIZE,
+    logs: [],
+    createdAt: Date.now(),
+    version: "v2",
+    agreedToTerms: false,
+    nevmAddress: draft.nevmAddress || undefined,
+    utxoAddress: draft.utxoAddress || undefined,
+    utxoXpub: draft.utxoXpub || undefined,
+    utxoAssetType: draft.utxoAssetType,
+  };
+};
 
 const isDirectionRoute = (id: unknown): id is TransferType =>
   id === "sys-to-nevm" || id === "nevm-to-sys";

--- a/utils/balance-hooks.ts
+++ b/utils/balance-hooks.ts
@@ -24,6 +24,49 @@ type Options = {
   retry?: boolean;
 };
 
+const normalizeBaseUnits = (value: string): string => {
+  const baseUnits = BigInt(value);
+  if (baseUnits < BigInt(0)) {
+    throw new Error("Balance cannot be negative");
+  }
+
+  return baseUnits.toString();
+};
+
+const fetchUtxoBalanceBaseUnits = async (
+  xpub: string,
+  address?: string,
+  assetGuid?: string
+): Promise<string> => {
+  if (!xpub || isValidEthereumAddress(xpub)) return "0";
+
+  const details = assetGuid && address ? "tokenBalances" : "basic";
+  const url = buildApiUrl(
+    `/api/utxo/xpub/${encodeURIComponent(xpub)}?details=${details}`
+  );
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error("Unable to load UTXO balance");
+  }
+
+  const result: BalanceResp = await response.json();
+  if (assetGuid && address) {
+    if (!result.tokensAsset) return "0";
+
+    return result.tokensAsset
+      .reduce(
+        (total, asset) =>
+          asset.assetGuid === assetGuid
+            ? total + BigInt(asset.balance)
+            : total,
+        BigInt(0)
+      )
+      .toString();
+  }
+
+  return normalizeBaseUnits(result.balance);
+};
+
 export const useUtxoBalance = (
   xpub: string,
   options: Options = { retry: true }
@@ -32,36 +75,24 @@ export const useUtxoBalance = (
   const { data: constants } = useConstants();
   return useQuery(
     ["utxo", "balance", xpub, address, assetGuid],
-    async () => {
-      if (!xpub || isValidEthereumAddress(xpub)) return Promise.resolve(0);
-      const details = assetGuid && address ? "tokenBalances" : "basic";
-      const url = buildApiUrl(
-        `/api/utxo/xpub/${encodeURIComponent(xpub)}?details=${details}`
-      );
-      const balanceInText = await fetch(url)
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error("Unable to load UTXO balance");
-          }
-          return res.json();
-        })
-        .then((res: BalanceResp) => {
-          if (assetGuid && address) {
-            if (!res.tokensAsset) {
-              return "0";
-            }
-            const total = res.tokensAsset.reduce((acc, asset) => {
-              if (asset.assetGuid === assetGuid) {
-                return acc + parseInt(asset.balance);
-              }
-              return acc;
-            }, 0);
-            return total.toString();
-          }
-          return res.balance;
-        });
-      return parseInt(balanceInText) / Math.pow(10, 8);
-    },
+    () => fetchUtxoBalanceBaseUnits(xpub, address, assetGuid),
+    {
+      retry,
+      enabled: Boolean(constants),
+      select: (balance: string) => Number(balance) / Math.pow(10, 8),
+    }
+  );
+};
+
+export const useUtxoBalanceBaseUnits = (
+  xpub: string,
+  options: Options = { retry: true }
+) => {
+  const { address, assetGuid, retry } = options;
+  const { data: constants } = useConstants();
+  return useQuery(
+    ["utxo", "balance", xpub, address, assetGuid],
+    () => fetchUtxoBalanceBaseUnits(xpub, address, assetGuid),
     {
       retry,
       enabled: Boolean(constants),
@@ -69,37 +100,63 @@ export const useUtxoBalance = (
   );
 };
 
+const fetchNevmBalanceBaseUnits = async (
+  address: string,
+  rpcUrl: string,
+  explorerUrl: string
+): Promise<string> => {
+  const web3 = new Web3(rpcUrl);
+  let balance = await web3.eth.getBalance(address).catch(() => undefined);
+
+  if (balance === undefined) {
+    const url = `${explorerUrl}/api?module=account&action=eth_get_balance&address=${address}&tag=latest`;
+    const response = await fetch(url).then((res) => res.json());
+    balance = response.result;
+  }
+
+  if (typeof balance !== "string") return "0";
+
+  try {
+    return normalizeBaseUnits(balance);
+  } catch {
+    return "0";
+  }
+};
+
 export const useNevmBalance = (address?: string) => {
   const { constants } = useConstants();
   return useQuery(
     ["nevm-rpc", "balance", constants?.rpc.nevm, address],
     async () => {
-      if (!address) return Promise.resolve(0);
+      if (!address) return "0";
 
       // Balance display is read-only and must not wake or switch the injected
       // wallet when Pali is operating in UTXO mode.
-      const web3 = new Web3(constants!.rpc.nevm);
-      let balRpc = await web3.eth
-        .getBalance(address)
-        .then(parseInt)
-        .catch(() => undefined);
+      return fetchNevmBalanceBaseUnits(
+        address,
+        constants!.rpc.nevm,
+        constants!.explorer.nevm
+      );
+    },
+    {
+      enabled: Boolean(constants?.rpc.nevm),
+      select: (balance: string) => Number(balance) / Math.pow(10, 18),
+    }
+  );
+};
 
-      if (balRpc === undefined) {
-        const url = `${
-          constants!.explorer.nevm
-        }/api?module=account&action=eth_get_balance&address=${address}&tag=latest`;
-        const ethBalanceInHex = await fetch(url)
-          .then((res) => res.json())
-          .then((rpcResp) => rpcResp.result);
-        const valueAsNumber = parseInt(ethBalanceInHex, 16);
-        if (isNaN(valueAsNumber)) {
-          return 0;
-        }
-        balRpc = valueAsNumber;
-      }
+export const useNevmBalanceBaseUnits = (address?: string) => {
+  const { constants } = useConstants();
+  return useQuery(
+    ["nevm-rpc", "balance", constants?.rpc.nevm, address],
+    async () => {
+      if (!address) return "0";
 
-      const ethBalance = balRpc / Math.pow(10, 18);
-      return ethBalance;
+      return fetchNevmBalanceBaseUnits(
+        address,
+        constants!.rpc.nevm,
+        constants!.explorer.nevm
+      );
     },
     {
       enabled: Boolean(constants?.rpc.nevm),

--- a/utils/syscoin-amount.test.ts
+++ b/utils/syscoin-amount.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 
 import {
-  toNonnegativeSyscoinBaseUnits,
+  floorSyscoinBaseUnits,
   toSyscoinBaseUnits,
 } from "./syscoin-amount";
 
@@ -21,10 +21,12 @@ describe("Syscoin amount conversion", () => {
     expect(toSyscoinBaseUnits("1.23")).toBe("123000000");
   });
 
-  it("allows a rounded maximum below one base unit to resolve to zero", () => {
-    expect(toNonnegativeSyscoinBaseUnits("0")).toBe("0");
-    expect(toNonnegativeSyscoinBaseUnits("0.00000000")).toBe("0");
-    expect(toNonnegativeSyscoinBaseUnits("0.00000001")).toBe("1");
+  it("floors calculated maxima to whole Syscoin base units", () => {
+    expect(floorSyscoinBaseUnits(0)).toBe("0");
+    expect(floorSyscoinBaseUnits(0.000000004)).toBe("0");
+    expect(floorSyscoinBaseUnits(0.00000001)).toBe("1");
+    expect(floorSyscoinBaseUnits(0.010000006)).toBe("1000000");
+    expect(floorSyscoinBaseUnits(0.01000001)).toBe("1000001");
   });
 
   it("rejects malformed, nonpositive, and over-precision values", () => {

--- a/utils/syscoin-amount.test.ts
+++ b/utils/syscoin-amount.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 
-import { toSyscoinBaseUnits } from "./syscoin-amount";
+import {
+  toNonnegativeSyscoinBaseUnits,
+  toSyscoinBaseUnits,
+} from "./syscoin-amount";
 
 describe("Syscoin amount conversion", () => {
   it("converts eight-decimal amounts without Number precision loss", () => {
@@ -16,6 +19,12 @@ describe("Syscoin amount conversion", () => {
     expect(toSyscoinBaseUnits("1")).toBe("100000000");
     expect(toSyscoinBaseUnits("0.00000001")).toBe("1");
     expect(toSyscoinBaseUnits("1.23")).toBe("123000000");
+  });
+
+  it("allows a rounded maximum below one base unit to resolve to zero", () => {
+    expect(toNonnegativeSyscoinBaseUnits("0")).toBe("0");
+    expect(toNonnegativeSyscoinBaseUnits("0.00000000")).toBe("0");
+    expect(toNonnegativeSyscoinBaseUnits("0.00000001")).toBe("1");
   });
 
   it("rejects malformed, nonpositive, and over-precision values", () => {

--- a/utils/syscoin-amount.test.ts
+++ b/utils/syscoin-amount.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { toSyscoinBaseUnits } from "./syscoin-amount";
+
+describe("Syscoin amount conversion", () => {
+  it("converts eight-decimal amounts without Number precision loss", () => {
+    expect(toSyscoinBaseUnits("67108864.00000038")).toBe(
+      "6710886400000038"
+    );
+    expect(toSyscoinBaseUnits("90071992.54740991")).toBe(
+      "9007199254740991"
+    );
+  });
+
+  it("pads whole and fractional SYS values to base units", () => {
+    expect(toSyscoinBaseUnits("1")).toBe("100000000");
+    expect(toSyscoinBaseUnits("0.00000001")).toBe("1");
+    expect(toSyscoinBaseUnits("1.23")).toBe("123000000");
+  });
+
+  it("rejects malformed, nonpositive, and over-precision values", () => {
+    for (const amount of [
+      "",
+      "0",
+      "-1",
+      "1e2",
+      "1.000000001",
+      "1".repeat(21),
+    ]) {
+      expect(() => toSyscoinBaseUnits(amount)).toThrow();
+    }
+  });
+});

--- a/utils/syscoin-amount.test.ts
+++ b/utils/syscoin-amount.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 
 import {
-  floorSyscoinBaseUnits,
+  formatSyscoinBaseUnits,
+  getTransferableSyscoinBaseUnits,
   toSyscoinBaseUnits,
 } from "./syscoin-amount";
 
@@ -21,12 +22,51 @@ describe("Syscoin amount conversion", () => {
     expect(toSyscoinBaseUnits("1.23")).toBe("123000000");
   });
 
-  it("floors calculated maxima to whole Syscoin base units", () => {
-    expect(floorSyscoinBaseUnits(0)).toBe("0");
-    expect(floorSyscoinBaseUnits(0.000000004)).toBe("0");
-    expect(floorSyscoinBaseUnits(0.00000001)).toBe("1");
-    expect(floorSyscoinBaseUnits(0.010000006)).toBe("1000000");
-    expect(floorSyscoinBaseUnits(0.01000001)).toBe("1000001");
+  it("derives transferable maxima from exact source-chain units", () => {
+    const reserveBaseUnits = toSyscoinBaseUnits("0.001");
+
+    expect(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: "1000000000000001",
+        balanceDecimals: 18,
+        reserveBaseUnits,
+      })
+    ).toBe("0");
+    expect(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: "11000006000000000",
+        balanceDecimals: 18,
+        reserveBaseUnits,
+      })
+    ).toBe("1000000");
+    expect(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: "11000150000000000",
+        balanceDecimals: 18,
+        reserveBaseUnits,
+      })
+    ).toBe("1000015");
+    expect(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: "1000015",
+        balanceDecimals: 8,
+        reserveBaseUnits: "0",
+      })
+    ).toBe("1000015");
+    expect(
+      getTransferableSyscoinBaseUnits({
+        balanceBaseUnits: "90071992547409910000000000",
+        balanceDecimals: 18,
+        reserveBaseUnits: "0",
+      })
+    ).toBe("9007199254740991");
+  });
+
+  it("formats exact Syscoin base units for validation messages", () => {
+    expect(formatSyscoinBaseUnits("0")).toBe("0");
+    expect(formatSyscoinBaseUnits("1")).toBe("0.00000001");
+    expect(formatSyscoinBaseUnits("1000015")).toBe("0.01000015");
+    expect(formatSyscoinBaseUnits("100000000")).toBe("1");
   });
 
   it("rejects malformed, nonpositive, and over-precision values", () => {

--- a/utils/syscoin-amount.ts
+++ b/utils/syscoin-amount.ts
@@ -1,5 +1,18 @@
 const SYSCOIN_DECIMALS = 8;
-const SYSCOIN_BASE_UNIT_FACTOR = 10 ** SYSCOIN_DECIMALS;
+
+const powerOfTen = (decimals: number): bigint =>
+  BigInt(`1${"0".repeat(decimals)}`);
+
+const SYSCOIN_BASE_UNIT_FACTOR = powerOfTen(SYSCOIN_DECIMALS);
+
+const parseNonnegativeInteger = (amount: string): bigint => {
+  const normalized = String(amount).trim();
+  if (!/^(0|[1-9]\d*)$/.test(normalized)) {
+    throw new Error("Base-unit amount must be a nonnegative integer");
+  }
+
+  return BigInt(normalized);
+};
 
 const parseSyscoinBaseUnits = (amount: string): bigint => {
   const normalized = String(amount).trim();
@@ -20,14 +33,38 @@ const parseSyscoinBaseUnits = (amount: string): bigint => {
   return BigInt(`${match[1]}${fraction.padEnd(SYSCOIN_DECIMALS, "0")}`);
 };
 
-export const floorSyscoinBaseUnits = (amount: number): string => {
-  if (!Number.isFinite(amount)) {
-    throw new Error("Amount must be finite");
+export const getTransferableSyscoinBaseUnits = ({
+  balanceBaseUnits,
+  balanceDecimals,
+  reserveBaseUnits,
+}: {
+  balanceBaseUnits: string;
+  balanceDecimals: number;
+  reserveBaseUnits: string;
+}): string => {
+  if (!Number.isInteger(balanceDecimals) || balanceDecimals < SYSCOIN_DECIMALS) {
+    throw new Error("Balance precision must be at least 8 decimals");
   }
 
-  return BigInt(
-    Math.floor(Math.max(0, amount) * SYSCOIN_BASE_UNIT_FACTOR)
-  ).toString();
+  const balance = parseNonnegativeInteger(balanceBaseUnits);
+  const reserve = parseNonnegativeInteger(reserveBaseUnits);
+  const sourceUnitFactor = powerOfTen(balanceDecimals - SYSCOIN_DECIMALS);
+  const balanceInSyscoinBaseUnits = balance / sourceUnitFactor;
+
+  return balanceInSyscoinBaseUnits > reserve
+    ? (balanceInSyscoinBaseUnits - reserve).toString()
+    : "0";
+};
+
+export const formatSyscoinBaseUnits = (amount: string): string => {
+  const baseUnits = parseNonnegativeInteger(amount);
+  const whole = baseUnits / SYSCOIN_BASE_UNIT_FACTOR;
+  const fraction = (baseUnits % SYSCOIN_BASE_UNIT_FACTOR)
+    .toString()
+    .padStart(SYSCOIN_DECIMALS, "0")
+    .replace(/0+$/, "");
+
+  return fraction ? `${whole}.${fraction}` : whole.toString();
 };
 
 export const toSyscoinBaseUnits = (amount: string): string => {

--- a/utils/syscoin-amount.ts
+++ b/utils/syscoin-amount.ts
@@ -1,4 +1,5 @@
 const SYSCOIN_DECIMALS = 8;
+const SYSCOIN_BASE_UNIT_FACTOR = 10 ** SYSCOIN_DECIMALS;
 
 const parseSyscoinBaseUnits = (amount: string): bigint => {
   const normalized = String(amount).trim();
@@ -19,8 +20,15 @@ const parseSyscoinBaseUnits = (amount: string): bigint => {
   return BigInt(`${match[1]}${fraction.padEnd(SYSCOIN_DECIMALS, "0")}`);
 };
 
-export const toNonnegativeSyscoinBaseUnits = (amount: string): string =>
-  parseSyscoinBaseUnits(amount).toString();
+export const floorSyscoinBaseUnits = (amount: number): string => {
+  if (!Number.isFinite(amount)) {
+    throw new Error("Amount must be finite");
+  }
+
+  return BigInt(
+    Math.floor(Math.max(0, amount) * SYSCOIN_BASE_UNIT_FACTOR)
+  ).toString();
+};
 
 export const toSyscoinBaseUnits = (amount: string): string => {
   const baseUnits = parseSyscoinBaseUnits(amount);

--- a/utils/syscoin-amount.ts
+++ b/utils/syscoin-amount.ts
@@ -1,0 +1,25 @@
+const SYSCOIN_DECIMALS = 8;
+
+export const toSyscoinBaseUnits = (amount: string): string => {
+  const normalized = String(amount).trim();
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/.exec(normalized);
+
+  if (!match) {
+    throw new Error("Amount must be a positive decimal number");
+  }
+  if (match[1].length > 20) {
+    throw new Error("Amount is too large");
+  }
+
+  const fraction = match[2] || "";
+  if (fraction.length > SYSCOIN_DECIMALS) {
+    throw new Error("Amount supports at most 8 decimal places");
+  }
+
+  const baseUnits = BigInt(`${match[1]}${fraction.padEnd(SYSCOIN_DECIMALS, "0")}`);
+  if (baseUnits <= BigInt(0)) {
+    throw new Error("Amount must be greater than zero");
+  }
+
+  return baseUnits.toString();
+};

--- a/utils/syscoin-amount.ts
+++ b/utils/syscoin-amount.ts
@@ -1,6 +1,6 @@
 const SYSCOIN_DECIMALS = 8;
 
-export const toSyscoinBaseUnits = (amount: string): string => {
+const parseSyscoinBaseUnits = (amount: string): bigint => {
   const normalized = String(amount).trim();
   const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/.exec(normalized);
 
@@ -16,7 +16,14 @@ export const toSyscoinBaseUnits = (amount: string): string => {
     throw new Error("Amount supports at most 8 decimal places");
   }
 
-  const baseUnits = BigInt(`${match[1]}${fraction.padEnd(SYSCOIN_DECIMALS, "0")}`);
+  return BigInt(`${match[1]}${fraction.padEnd(SYSCOIN_DECIMALS, "0")}`);
+};
+
+export const toNonnegativeSyscoinBaseUnits = (amount: string): string =>
+  parseSyscoinBaseUnits(amount).toString();
+
+export const toSyscoinBaseUnits = (amount: string): string => {
+  const baseUnits = parseSyscoinBaseUnits(amount);
   if (baseUnits <= BigInt(0)) {
     throw new Error("Amount must be greater than zero");
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7018,13 +7018,6 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-satoshi-bitcoin@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/satoshi-bitcoin/-/satoshi-bitcoin-1.0.5.tgz#d2a2b12dd904715e4ca17e17493ffff75ce2af72"
-  integrity sha512-iCUOSe8yTOqetYcj/n4ziv0psqRMRZT4+YhcMrQIYpjnx3Pgn9uiTlaUItNMMB/0sldINEGkJvxwTW55OfrYPg==
-  dependencies:
-    big.js "^3.1.3"
-
 scheduler@^0.23.0:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"


### PR DESCRIPTION
## Summary
- replace `satoshi-bitcoin` with exact string-to-`BigInt` base-unit conversion
- preserve the amount as a string from the bridge form through transfer persistence
- remove the six-decimal truncation in the SYS-to-SYSX step
- use exact amounts in normal and sponsored burn builders and sponsorship eligibility
- reject malformed, over-precision, nonpositive, and unreasonably long amounts

## Root cause
The bridge form and burn paths converted decimal strings through JavaScript `number`. That can change an atomic unit for large values and truncates valid seventh/eighth decimal places in the SYS-to-NEVM flow.

## Impact
Valid amounts retain all eight Syscoin decimals through the complete client and sponsor path. The bridge no longer depends on `satoshi-bitcoin`.

## Validation
- `yarn test --runInBand utils/syscoin-amount.test.ts api/services/__tests__/sponsor-wallet.test.ts api/routes/__tests__/sponsor-utxo-eligibility.test.ts` (35 tests)
- changed-file ESLint
- `git diff --check`

The repository-wide `tsc --noEmit` remains blocked by pre-existing test files that use Jest globals without `@types/jest`; the changed files pass ESLint and their focused suites.