### PR TITLE
Return 404 for missing transfers

### DIFF
--- a/api/routes/__tests__/transfer-patch.test.ts
+++ b/api/routes/__tests__/transfer-patch.test.ts
@@ -1,20 +1,33 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockUpsertTransfer = jest.fn<any>();
+const mockGetTransfer = jest.fn<any>();
 
-jest.mock("api/services/transfer", () => ({
-  TransferService: jest.fn().mockImplementation(() => ({
-    getTransfer: jest.fn(),
-    upsertTransfer: mockUpsertTransfer,
-  })),
-}));
+jest.mock("api/services/transfer", () => {
+  class TransferNotFoundError extends Error {
+    constructor() {
+      super("Transfer not found");
+      this.name = "TransferNotFoundError";
+      Object.setPrototypeOf(this, TransferNotFoundError.prototype);
+    }
+  }
+
+  return {
+    TransferNotFoundError,
+    TransferService: jest.fn().mockImplementation(() => ({
+      getTransfer: mockGetTransfer,
+      upsertTransfer: mockUpsertTransfer,
+    })),
+  };
+});
 jest.mock("lib/mongodb", () => jest.fn());
 jest.mock("utils/api/cors", () => ({
   applyApiCors: jest.fn(() => false),
 }));
 
 import { NextApiRequest, NextApiResponse } from "next";
-import { patchRequest } from "pages/api/transfer/[id]";
+import { TransferNotFoundError } from "api/services/transfer";
+import { getRequest, patchRequest } from "pages/api/transfer/[id]";
 
 const createResponse = () => {
   const response = {
@@ -43,5 +56,36 @@ describe("transfer PATCH binding", () => {
 
     expect(response.status).toHaveBeenCalledWith(400);
     expect(mockUpsertTransfer).not.toHaveBeenCalled();
+  });
+});
+
+describe("transfer GET errors", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 404 when the transfer does not exist", async () => {
+    mockGetTransfer.mockRejectedValue(new TransferNotFoundError());
+    const request = {
+      query: { id: "missing-transfer" },
+    } as unknown as NextApiRequest;
+    const response = createResponse();
+
+    await getRequest(request, response);
+
+    expect(response.status).toHaveBeenCalledWith(404);
+    expect(response.json).toHaveBeenCalledWith({
+      message: "Transfer not found",
+    });
+  });
+
+  it("does not mask unexpected server errors", async () => {
+    const error = new Error("Database unavailable");
+    mockGetTransfer.mockRejectedValue(error);
+    const request = {
+      query: { id: "existing-transfer" },
+    } as unknown as NextApiRequest;
+
+    await expect(getRequest(request, createResponse())).rejects.toBe(error);
   });
 });

--- a/api/services/__tests__/transfer.test.ts
+++ b/api/services/__tests__/transfer.test.ts
@@ -23,6 +23,7 @@ import {
   ITransfer,
 } from "@contexts/Transfer/types";
 import {
+  TransferNotFoundError,
   TransferService,
   TransferWriteUnauthorizedError,
 } from "../transfer";
@@ -58,6 +59,14 @@ describe("TransferService write capabilities", () => {
       new TransferService().upsertTransfer(transfer)
     ).rejects.toBeInstanceOf(TransferWriteUnauthorizedError);
     expect(TransferModelMock.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("throws a typed error when a transfer does not exist", async () => {
+    TransferModelMock.findOne.mockResolvedValue(null);
+
+    await expect(
+      new TransferService().getTransfer("missing-transfer")
+    ).rejects.toBeInstanceOf(TransferNotFoundError);
   });
 
   it("updates only the URL-bound transfer when the capability matches", async () => {

--- a/api/services/transfer.ts
+++ b/api/services/transfer.ts
@@ -15,6 +15,14 @@ export class TransferWriteUnauthorizedError extends Error {
   }
 }
 
+export class TransferNotFoundError extends Error {
+  constructor() {
+    super("Transfer not found");
+    this.name = "TransferNotFoundError";
+    Object.setPrototypeOf(this, TransferNotFoundError.prototype);
+  }
+}
+
 type TransferWriteResult = {
   transfer: ITransfer;
 };
@@ -82,7 +90,7 @@ export class TransferService {
     const transfer = await TransferModel.findOne({ id });
 
     if (!transfer) {
-      throw new Error("Transfer not found");
+      throw new TransferNotFoundError();
     }
 
     return transfer as unknown as ITransfer;

--- a/pages/api/transfer/[id].ts
+++ b/pages/api/transfer/[id].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import {
+  TransferNotFoundError,
   TransferService,
   TransferWriteUnauthorizedError,
 } from "api/services/transfer";
@@ -8,15 +9,25 @@ import { applyApiCors } from "utils/api/cors";
 
 const transferService = new TransferService();
 
-const getRequest = async (req: NextApiRequest, res: NextApiResponse) => {
+export const getRequest = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
   const { id } = req.query;
 
   if (!id) {
     return res.status(400).json({ message: "Missing id" });
   }
 
-  const transfer = await transferService.getTransfer(id as string);
-  return res.status(200).json(transfer);
+  try {
+    const transfer = await transferService.getTransfer(id as string);
+    return res.status(200).json(transfer);
+  } catch (error) {
+    if (error instanceof TransferNotFoundError) {
+      return res.status(404).json({ message: error.message });
+    }
+    throw error;
+  }
 };
 
 export const patchRequest = async (


### PR DESCRIPTION
## What changed

- add a typed `TransferNotFoundError` for absent transfer records
- return HTTP 404 with `{ "message": "Transfer not found" }` from `GET /api/transfer/:id`
- keep unexpected backend and database failures as HTTP 500 responses
- add service and route regression coverage

## Why

Looking up a transfer ID in the wrong network database currently throws a generic error that Next.js exposes as HTTP 500. A missing record is an expected client-visible condition and should be classified as 404 without masking genuine server failures.

## Validation

- `npm test -- --runInBand` — 28 suites, 151 tests passed
- `npm run lint`
- `sh deploy/docker-compose.test.sh`
- `sh deploy/restore-mongo-env.test.sh`
- `sh deploy/validate-env.test.sh`
- production `npm run build`
