### PR TITLE
Reset UTXO selection on account change

### DIFF
--- a/components/Bridge/WalletSwitch/UTXOConnect.tsx
+++ b/components/Bridge/WalletSwitch/UTXOConnect.tsx
@@ -16,6 +16,7 @@ import WalletSwitchConfirmCard from "./ConfirmCard";
 import { MIN_GAS_AMOUNT } from "@constants";
 import { useFeatureFlags } from "../hooks/useFeatureFlags";
 import {
+  clearUtxoSelectionBeforeAccountChange,
   connectPaliUtxoAccount,
   hasPaliUtxoAccountDetails,
   switchToSyscoinThenChangeAccount,
@@ -200,17 +201,22 @@ const UTXOConnect: React.FC<UTXOConnectProps> = (props) => {
     );
 
   const change = () => {
-    if (
-      isBitcoinBased &&
-      !hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)
-    ) {
-      return connect();
-    }
+    return clearUtxoSelectionBeforeAccountChange(
+      setUtxo,
+      () => {
+        if (
+          isBitcoinBased &&
+          !hasPaliUtxoAccountDetails(connectedAccount, xpubAddress)
+        ) {
+          return connect();
+        }
 
-    return switchToSyscoinThenChangeAccount(
-      isBitcoinBased,
-      switchTo,
-      changeAccount
+        return switchToSyscoinThenChangeAccount(
+          isBitcoinBased,
+          switchTo,
+          changeAccount
+        );
+      }
     );
   };
 

--- a/contexts/PaliWallet/utxo-network.test.ts
+++ b/contexts/PaliWallet/utxo-network.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import {
+  clearUtxoSelectionBeforeAccountChange,
   connectPaliUtxoAccount,
   discoverPaliUtxoAccount,
   getPaliSyscoinSwitchRequest,
@@ -9,6 +10,19 @@ import {
 } from "./utxo-network";
 
 describe("Pali Syscoin UTXO network handling", () => {
+  it("clears the bridge selection before opening the account picker", async () => {
+    const calls: string[] = [];
+    const setUtxo = jest.fn(() => calls.push("clear"));
+    const changeAccount = jest.fn(async () => {
+      calls.push("change-account");
+    });
+
+    await clearUtxoSelectionBeforeAccountChange(setUtxo, changeAccount);
+
+    expect(setUtxo).toHaveBeenCalledWith({ address: "", xpub: "" });
+    expect(calls).toEqual(["clear", "change-account"]);
+  });
+
   it("discovers an existing account without opening an interactive request", async () => {
     const request = jest.fn(async () => ({ address: "sys1-existing" }));
 

--- a/contexts/PaliWallet/utxo-network.ts
+++ b/contexts/PaliWallet/utxo-network.ts
@@ -21,6 +21,19 @@ type PaliUtxoAccount = {
   address?: unknown;
 };
 
+type UtxoSelectionSetter = (selection: {
+  address: string;
+  xpub: string;
+}) => void;
+
+export const clearUtxoSelectionBeforeAccountChange = <T>(
+  setUtxo: UtxoSelectionSetter,
+  changeAccount: () => T
+): T => {
+  setUtxo({ address: "", xpub: "" });
+  return changeAccount();
+};
+
 export const discoverPaliUtxoAccount = async (
   provider: Pick<PaliProvider, "request">
 ): Promise<string | null> => {


### PR DESCRIPTION
## What changed

- clear the bridge's selected UTXO address and xpub before opening the current Pali account picker
- return the UTXO card to the explicit “Use Account” confirmation state, matching the NEVM flow
- add a regression test proving the selection is cleared before account change begins

## Root cause

The NEVM `Change` handler cleared its form selection before opening the wallet, but the UTXO handler retained the previous transfer address and xpub. Pali refreshed its active account internally while React continued rendering the persisted selection until a page refresh.

## Scope

This behavioral change is limited to the current Pali v2 UTXO path.

## Validation

- `npm test -- --runInBand` — 29 suites, 157 tests passed
- `npm run lint`
- `sh deploy/docker-compose.test.sh`
- `sh deploy/restore-mongo-env.test.sh`
- `sh deploy/validate-env.test.sh`
- production `npm run build`
