### PR TITLE
Persist wallet selections across refresh

### DIFF
--- a/components/Bridge/StepSwitch.tsx
+++ b/components/Bridge/StepSwitch.tsx
@@ -15,7 +15,7 @@ import BridgeStepGenerateProofs from "./Steps/GenerateProofs";
 import BridgeStepMintSysx from "./Steps/MintSysx";
 import BridgeStepSubmitProofs from "./Steps/SubmitProofs";
 import { useTransfer } from "./context/TransferContext";
-import type { ConnectValidateDraft } from "./Steps/ConnectValidate";
+import type { ConnectValidateDraft } from "./connect-validate-draft";
 
 type BridgeStepSwitchProps = {
   onConnectValidateDraftChange?: (draft: ConnectValidateDraft) => void;

--- a/components/Bridge/Steps/ConnectValidate.tsx
+++ b/components/Bridge/Steps/ConnectValidate.tsx
@@ -29,6 +29,7 @@ import {
 import { Box, Typography } from "@mui/material";
 
 import { useTransfer } from "../context/TransferContext";
+import type { ConnectValidateDraft } from "../connect-validate-draft";
 import BridgeLoading from "../Loading";
 import { ConnectValidateAgreeToTermsCheckbox } from "./ConnectValidate/AgreeToTermsCheckbox";
 import { ConnectValidateAmountField } from "./ConnectValidate/AmountField";
@@ -84,14 +85,6 @@ type ConnectValidateFormData = {
   utxoAddress: string;
   utxoXpub: string;
   agreedToTerms: boolean;
-  utxoAssetType?: "sys" | "sysx";
-};
-
-export type ConnectValidateDraft = {
-  amount?: string;
-  nevmAddress: string;
-  utxoAddress: string;
-  utxoXpub: string;
   utxoAssetType?: "sys" | "sysx";
 };
 

--- a/components/Bridge/connect-validate-draft.test.ts
+++ b/components/Bridge/connect-validate-draft.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import {
+  clearConnectValidateDraft,
+  readConnectValidateDraft,
+  writeConnectValidateDraft,
+} from "./connect-validate-draft";
+
+const createStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    getItem: jest.fn((key: string) => values.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: jest.fn((key: string) => values.delete(key)),
+  };
+};
+
+describe("connect and validate draft storage", () => {
+  it("restores both wallet selections together", () => {
+    const storage = createStorage();
+    const draft = {
+      amount: "0.1",
+      nevmAddress: "0x6781dd2b72002f1fb37e7415479cbf5ffe828bfb",
+      utxoAddress: "tsys1q56292azekef7fcnydp5v6mwrm5w7cacw9ahy70",
+      utxoXpub: "upub-selected-account",
+      utxoAssetType: "sys" as const,
+    };
+
+    writeConnectValidateDraft(storage, draft);
+
+    expect(readConnectValidateDraft(storage)).toEqual(draft);
+  });
+
+  it("ignores malformed stored data", () => {
+    const storage = createStorage();
+    storage.setItem("syscoin-bridge-connect-draft-v1", "not-json");
+
+    expect(readConnectValidateDraft(storage)).toEqual({});
+  });
+
+  it("clears the draft after leaving the new-transfer routes", () => {
+    const storage = createStorage();
+    writeConnectValidateDraft(storage, { nevmAddress: "0x123" });
+
+    clearConnectValidateDraft(storage);
+
+    expect(readConnectValidateDraft(storage)).toEqual({});
+  });
+});

--- a/components/Bridge/connect-validate-draft.ts
+++ b/components/Bridge/connect-validate-draft.ts
@@ -1,0 +1,69 @@
+export type ConnectValidateDraft = {
+  amount?: string;
+  nevmAddress: string;
+  utxoAddress: string;
+  utxoXpub: string;
+  utxoAssetType?: "sys" | "sysx";
+};
+
+type DraftStorageReader = Pick<Storage, "getItem">;
+type DraftStorageWriter = Pick<Storage, "setItem">;
+type DraftStorageRemover = Pick<Storage, "removeItem">;
+
+const STORAGE_KEY = "syscoin-bridge-connect-draft-v1";
+const MAX_DRAFT_VALUE_LENGTH = 512;
+
+const readDraftString = (value: unknown) =>
+  typeof value === "string" && value.length <= MAX_DRAFT_VALUE_LENGTH
+    ? value
+    : undefined;
+
+export const readConnectValidateDraft = (
+  storage: DraftStorageReader
+): Partial<ConnectValidateDraft> => {
+  try {
+    const stored = storage.getItem(STORAGE_KEY);
+    if (!stored) return {};
+
+    const draft = JSON.parse(stored) as Record<string, unknown> | null;
+    if (!draft || typeof draft !== "object" || Array.isArray(draft)) return {};
+
+    const amount = readDraftString(draft.amount);
+    const nevmAddress = readDraftString(draft.nevmAddress);
+    const utxoAddress = readDraftString(draft.utxoAddress);
+    const utxoXpub = readDraftString(draft.utxoXpub);
+    const utxoAssetType =
+      draft.utxoAssetType === "sys" || draft.utxoAssetType === "sysx"
+        ? draft.utxoAssetType
+        : undefined;
+
+    return {
+      ...(amount !== undefined && { amount }),
+      ...(nevmAddress !== undefined && { nevmAddress }),
+      ...(utxoAddress !== undefined && { utxoAddress }),
+      ...(utxoXpub !== undefined && { utxoXpub }),
+      ...(utxoAssetType !== undefined && { utxoAssetType }),
+    };
+  } catch {
+    return {};
+  }
+};
+
+export const writeConnectValidateDraft = (
+  storage: DraftStorageWriter,
+  draft: Partial<ConnectValidateDraft>
+) => {
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(draft));
+  } catch {
+    // A blocked or full browser store must not prevent starting a transfer.
+  }
+};
+
+export const clearConnectValidateDraft = (storage: DraftStorageRemover) => {
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // A blocked browser store is equivalent to having no saved draft.
+  }
+};

--- a/pages/bridge/[id].tsx
+++ b/pages/bridge/[id].tsx
@@ -17,7 +17,12 @@ import TransferTitle from "components/Bridge/Transfer/Title";
 import BridgeSavingIndicator from "components/Bridge/SavingIndicator";
 import BridgeStepSwitch from "components/Bridge/StepSwitch";
 import BridgeStepper from "components/Bridge/Stepper";
-import type { ConnectValidateDraft } from "components/Bridge/Steps/ConnectValidate";
+import {
+  clearConnectValidateDraft,
+  type ConnectValidateDraft,
+  readConnectValidateDraft,
+  writeConnectValidateDraft,
+} from "components/Bridge/connect-validate-draft";
 import { SyscoinProvider } from "components/Bridge/context/Syscoin";
 import {
   TransferContextProvider,
@@ -26,11 +31,12 @@ import {
 import { Web3Provider } from "components/Bridge/context/Web";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import NextLink from "next/link";
 import BridgeTransferSwitchTypeCard from "components/Bridge/TransferSwitchTypeCard";
 import BridgeNewTransferButton from "components/Bridge/NewTransferButton";
+import BridgeLoading from "components/Bridge/Loading";
 import { toSyscoinBaseUnits } from "utils/syscoin-amount";
 
 const getDraftAmount = (amount?: string) => {
@@ -79,22 +85,43 @@ const createTransfer = (
 const isDirectionRoute = (id: unknown): id is TransferType =>
   id === "sys-to-nevm" || id === "nevm-to-sys";
 
+const getSessionStorage = () => {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return undefined;
+  }
+};
+
 const BridgePage: NextPage = () => {
-  const { query } = useRouter();
+  const { isReady, query } = useRouter();
   const connectValidateDraft = useRef<Partial<ConnectValidateDraft>>({});
+  const [isDraftHydrated, setIsDraftHydrated] = useState(false);
 
   useEffect(() => {
-    if (!isDirectionRoute(query.id)) {
+    if (!isReady) return;
+
+    const storage = getSessionStorage();
+    if (isDirectionRoute(query.id)) {
+      connectValidateDraft.current = storage
+        ? readConnectValidateDraft(storage)
+        : {};
+    } else {
       connectValidateDraft.current = {};
+      if (storage) clearConnectValidateDraft(storage);
     }
-  }, [query.id]);
+    setIsDraftHydrated(true);
+  }, [isReady, query.id]);
 
   const handleConnectValidateDraftChange = useCallback(
     (draft: ConnectValidateDraft) => {
-      connectValidateDraft.current = {
+      const nextDraft = {
         ...connectValidateDraft.current,
         ...draft,
       };
+      connectValidateDraft.current = nextDraft;
+      const storage = getSessionStorage();
+      if (storage) writeConnectValidateDraft(storage, nextDraft);
     },
     []
   );
@@ -102,12 +129,17 @@ const BridgePage: NextPage = () => {
   const initialTransfer = useMemo(() => {
     const id = query.id;
     if (isDirectionRoute(id)) {
-      return createTransfer(id, connectValidateDraft.current);
+      return createTransfer(
+        id,
+        isDraftHydrated ? connectValidateDraft.current : {}
+      );
     }
     return {
       id,
     } as ITransfer;
-  }, [query.id]);
+  }, [isDraftHydrated, query.id]);
+
+  const isLoadingDraft = isDirectionRoute(query.id) && !isDraftHydrated;
 
   return (
     <SyscoinProvider>
@@ -145,11 +177,15 @@ const BridgePage: NextPage = () => {
                 }}
               >
                 <CardContent>
-                  <BridgeStepSwitch
-                    onConnectValidateDraftChange={
-                      handleConnectValidateDraftChange
-                    }
-                  />
+                  {isLoadingDraft ? (
+                    <BridgeLoading />
+                  ) : (
+                    <BridgeStepSwitch
+                      onConnectValidateDraftChange={
+                        handleConnectValidateDraftChange
+                      }
+                    />
+                  )}
                   <BridgeSavingIndicator />
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary

- persist the connect-and-validate draft in tab-scoped session storage
- restore UTXO address/xpub, NEVM address, amount, and asset selection together after refresh
- clear the draft after entering a persisted transfer and fail safely when browser storage is unavailable or malformed
- move the shared draft type into the persistence module and add regression coverage

## Root cause

The selected accounts lived only in React memory until a transfer was started. After a reload, Pali could rediscover only the account for its currently active network, so the opposite side appeared to be lost.

## User impact

Refreshing either new-transfer direction now preserves both confirmed wallet selections independently of Pali's active network. Actual transfers and later new-transfer flows do not inherit a stale draft.

## Validation

- `npm test -- --runInBand` (30 suites, 160 tests)
- `npm run lint`
- `env -u SECRET_COOKIE_PASSWORD INTERNAL_API_BASE_URL=https://bridge-api.tanenbaum.io npm run build`
- `sh deploy/docker-compose.test.sh`
- `sh deploy/restore-mongo-env.test.sh`
- `sh deploy/validate-env.test.sh`